### PR TITLE
Supports for french addresses

### DIFF
--- a/classification/StopWordsClassification.js
+++ b/classification/StopWordsClassification.js
@@ -1,0 +1,10 @@
+const Classification = require('./Classification')
+
+class StopWordsClassification extends Classification {
+  constructor (confidence, meta) {
+    super(confidence, meta)
+    this.label = 'stop_words'
+  }
+}
+
+module.exports = StopWordsClassification

--- a/classification/StopWordsClassification.test.js
+++ b/classification/StopWordsClassification.test.js
@@ -1,0 +1,24 @@
+const Classification = require('./StopWordsClassification')
+
+module.exports.tests = {}
+
+module.exports.tests.constructor = (test) => {
+  test('constructor', (t) => {
+    let c = new Classification()
+    t.false(c.public)
+    t.equals(c.label, 'stop_words')
+    t.equals(c.confidence, 1.0)
+    t.deepEqual(c.meta, {})
+    t.end()
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`StopWordsClassification: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classification/StreetPrefixClassification.js
+++ b/classification/StreetPrefixClassification.js
@@ -1,0 +1,10 @@
+const Classification = require('./Classification')
+
+class StreetPrefixClassification extends Classification {
+  constructor (confidence, meta) {
+    super(confidence, meta)
+    this.label = 'street_prefix'
+  }
+}
+
+module.exports = StreetPrefixClassification

--- a/classification/StreetPrefixClassification.test.js
+++ b/classification/StreetPrefixClassification.test.js
@@ -1,0 +1,24 @@
+const Classification = require('./StreetPrefixClassification')
+
+module.exports.tests = {}
+
+module.exports.tests.constructor = (test) => {
+  test('constructor', (t) => {
+    let c = new Classification()
+    t.false(c.public)
+    t.equals(c.label, 'street_prefix')
+    t.equals(c.confidence, 1.0)
+    t.deepEqual(c.meta, {})
+    t.end()
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`StreetPrefixClassification: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/StopWordsClassifier.js
+++ b/classifier/StopWordsClassifier.js
@@ -1,0 +1,30 @@
+const WordClassifier = require('./super/WordClassifier')
+const StopWordsClassification = require('../classification/StopWordsClassification')
+const libpostal = require('../resources/libpostal/libpostal')
+
+// dictionaries sourced from the libpostal project
+// see: https://github.com/openvenues/libpostal
+
+class StopWordsClassifier extends WordClassifier {
+  setup () {
+    // load stopwords tokens
+    this.stopWords = {}
+    libpostal.load(this.stopWords, ['fr'], 'stopwords.txt')
+  }
+
+  each (span) {
+    // skip spans which contain numbers
+    if (span.contains.numerals) { return }
+
+    // base confidence
+    let confidence = 0.75
+
+    // use an inverted index for full token matching as it's O(1)
+    if (this.stopWords.hasOwnProperty(span.norm)) {
+      if (span.norm.length < 2) { confidence = 0.2 }
+      span.classify(new StopWordsClassification(confidence))
+    }
+  }
+}
+
+module.exports = StopWordsClassifier

--- a/classifier/StopWordsClassifier.test.js
+++ b/classifier/StopWordsClassifier.test.js
@@ -1,0 +1,50 @@
+const StopWordsClassifier = require('./StopWordsClassifier')
+const StopWordsClassification = require('../classification/StopWordsClassification')
+const Span = require('../tokenization/Span')
+
+module.exports.tests = {}
+
+function classify (body) {
+  let c = new StopWordsClassifier()
+  let s = new Span(body)
+  c.each(s, null, 1)
+  return s
+}
+
+module.exports.tests.contains_numerals = (test) => {
+  test('contains numerals: honours contains.numerals boolean', (t) => {
+    let c = new StopWordsClassifier()
+    let s = new Span('example')
+    s.contains.numerals = true
+    c.each(s, null, 1)
+    t.deepEqual(s.classifications, {})
+    t.end()
+  })
+}
+
+module.exports.tests.french_stop_words = (test) => {
+  let valid = [
+    'de', 'la', 'l\'',
+    'du', 'à', 'sur'
+  ]
+
+  valid.forEach(token => {
+    test(`french stop_words: ${token}`, (t) => {
+      let s = classify(token)
+      t.deepEqual(s.classifications, {
+        StopWordsClassification: new StopWordsClassification(token.length > 1 ? 0.75 : 0.2)
+      })
+      t.end()
+    })
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`StopWordsClassifier: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/StreetPrefixClassifier.js
+++ b/classifier/StreetPrefixClassifier.js
@@ -1,0 +1,37 @@
+const WordClassifier = require('./super/WordClassifier')
+const StreetPrefixClassification = require('../classification/StreetPrefixClassification')
+const libpostal = require('../resources/libpostal/libpostal')
+
+// dictionaries sourced from the libpostal project
+// see: https://github.com/openvenues/libpostal
+
+class StreetPrefixClassifier extends WordClassifier {
+  setup () {
+    // load street tokens
+    this.streetTypes = {}
+    libpostal.load(this.streetTypes, ['fr'], 'street_types.txt')
+  }
+
+  each (span) {
+    // skip spans which contain numbers
+    if (span.contains.numerals) { return }
+
+    // base confidence
+    let confidence = 1
+
+    // use an inverted index for full token matching as it's O(1)
+    if (this.streetTypes.hasOwnProperty(span.norm)) {
+      if (span.norm.length < 2) { confidence = 0.2 } // single letter streets are uncommon
+      span.classify(new StreetPrefixClassification(confidence))
+      return
+    }
+
+    // try again for abbreviations denoted by a period such as 'str.', also O(1)
+    if (span.contains.final.period && this.streetTypes.hasOwnProperty(span.norm.slice(0, -1))) {
+      if (span.norm.length < 3) { confidence = 0.2 } // single letter streets are uncommon
+      span.classify(new StreetPrefixClassification(confidence))
+    }
+  }
+}
+
+module.exports = StreetPrefixClassifier

--- a/classifier/StreetPrefixClassifier.test.js
+++ b/classifier/StreetPrefixClassifier.test.js
@@ -1,0 +1,51 @@
+const StreetPrefixClassifier = require('./StreetPrefixClassifier')
+const StreetPrefixClassification = require('../classification/StreetPrefixClassification')
+const Span = require('../tokenization/Span')
+
+module.exports.tests = {}
+
+function classify (body) {
+  let c = new StreetPrefixClassifier()
+  let s = new Span(body)
+  c.each(s, null, 1)
+  return s
+}
+
+module.exports.tests.contains_numerals = (test) => {
+  test('contains numerals: honours contains.numerals boolean', (t) => {
+    let c = new StreetPrefixClassifier()
+    let s = new Span('example')
+    s.contains.numerals = true
+    c.each(s, null, 1)
+    t.deepEqual(s.classifications, {})
+    t.end()
+  })
+}
+
+module.exports.tests.french_prefix = (test) => {
+  let valid = [
+    'rue', 'allée', 'allee',
+    'avenue', 'av', 'rt.',
+    'boulevard', 'blvd', 'blvd.'
+  ]
+
+  valid.forEach(token => {
+    test(`french prefix: ${token}`, (t) => {
+      let s = classify(token)
+      t.deepEqual(s.classifications, {
+        StreetPrefixClassification: new StreetPrefixClassification(token.length > 1 ? 1.0 : 0.2)
+      })
+      t.end()
+    })
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`StreetPrefixClassifier: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/StreetSuffixClassifier.js
+++ b/classifier/StreetSuffixClassifier.js
@@ -9,7 +9,8 @@ class StreetSuffixClassifier extends WordClassifier {
   setup () {
     // load street tokens
     this.streetTypes = {}
-    libpostal.load(this.streetTypes, libpostal.languages, 'street_types.txt')
+    // Exclude french types because they are street prefix
+    libpostal.load(this.streetTypes, libpostal.languages.filter(e => e !== 'fr'), 'street_types.txt')
 
     // blacklist
     // this Italian contracted form of Androna causes issues in English

--- a/classifier/scheme/street.js
+++ b/classifier/scheme/street.js
@@ -208,5 +208,62 @@ module.exports = [
         not: ['StreetClassification']
       }
     ]
+  },
+  {
+    // Rue Montmartre
+    confidence: 1.0,
+    Class: StreetClassification,
+    scheme: [
+      {
+        is: ['StreetPrefixClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['AlphaClassification'],
+        not: ['StreetClassification']
+      }
+    ]
+  },
+  {
+    // Rue Du Paris
+    confidence: 1.0,
+    Class: StreetClassification,
+    scheme: [
+      {
+        is: ['StreetPrefixClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['StopWordsClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['AlphaClassification'],
+        not: ['StreetClassification']
+      }
+    ]
+  },
+  {
+    // Boulevard De La Paix
+    confidence: 1.0,
+    Class: StreetClassification,
+    scheme: [
+      {
+        is: ['StreetPrefixClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['StopWordsClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['StopWordsClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['AlphaClassification'],
+        not: ['StreetClassification']
+      }
+    ]
   }
 ]

--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -2,10 +2,12 @@ const Parser = require('./Parser')
 const AlphaNumericClassifier = require('../classifier/AlphaNumericClassifier')
 const HouseNumberClassifier = require('../classifier/HouseNumberClassifier')
 const PostcodeClassifier = require('../classifier/PostcodeClassifier')
+const StreetPrefixClassifier = require('../classifier/StreetPrefixClassifier')
 const StreetSuffixClassifier = require('../classifier/StreetSuffixClassifier')
 const CompoundStreetClassifier = require('../classifier/CompoundStreetClassifier')
 const DirectionalClassifier = require('../classifier/DirectionalClassifier')
 const OrdinalClassifier = require('../classifier/OrdinalClassifier')
+const StopWordsClassifier = require('../classifier/StopWordsClassifier')
 const PersonClassifier = require('../classifier/PersonClassifier')
 const GivenNameClassifier = require('../classifier/GivenNameClassifier')
 const SurnameClassifier = require('../classifier/SurnameClassifier')
@@ -31,10 +33,12 @@ class AddressParser extends Parser {
         // word classifiers
         new HouseNumberClassifier(),
         new PostcodeClassifier(),
+        new StreetPrefixClassifier(),
         new StreetSuffixClassifier(),
         new CompoundStreetClassifier(),
         new DirectionalClassifier(),
         new OrdinalClassifier(),
+        new StopWordsClassifier(),
 
         // phrase classifiers
         new IntersectionClassifier(),


### PR DESCRIPTION
Hi there,

I added some classifiers to take into account the French language.
The street type is at the beginning of the street.

## Supports for:

- Rue Montmartre (Street + Alpha)
- Rue de Paris (Street + Stop Word + Alpha)
- Rue de la Paix (Street + 2 Stop Words + Alpha)

These are the most common addresses.

## Do not support

- Rue Saint Lazarre (Result is `{ street: 'Rue Saint' }`) => Saint + Name
- Rue Jean Nicot (Result is `{ street: 'Rue Jean' }`) => First Name + Last Name