### PR TITLE
Add person composite classifier

### DIFF
--- a/classifier/scheme/person.js
+++ b/classifier/scheme/person.js
@@ -1,0 +1,88 @@
+const PersonClassification = require('../../classification/PersonClassification')
+const GivenNameClassification = require('../../classification/GivenNameClassification')
+
+module.exports = [
+  {
+    // Anne Marie
+    confidence: 0.25,
+    Class: GivenNameClassification,
+    scheme: [
+      {
+        is: ['GivenNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['GivenNameClassification'],
+        not: ['StreetClassification', 'StreetPrefixClassification', 'StopWordClassification']
+      }
+    ]
+  },
+  {
+    // Georges Bizet
+    confidence: 0.5,
+    Class: PersonClassification,
+    scheme: [
+      {
+        is: ['GivenNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['SurnameClassification'],
+        not: ['StreetClassification', 'StreetPrefixClassification', 'StopWordClassification']
+      }
+    ]
+  },
+  {
+    // Rose de Lima
+    confidence: 0.5,
+    Class: PersonClassification,
+    scheme: [
+      {
+        is: ['GivenNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['StopWordClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['SurnameClassification'],
+        not: ['StreetClassification', 'StreetPrefixClassification', 'StopWordClassification']
+      }
+    ]
+  },
+  {
+    // Unknown surname
+    confidence: 0.1,
+    Class: PersonClassification,
+    scheme: [
+      {
+        is: ['GivenNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['AlphaClassification'],
+        not: ['StreetClassification', 'StreetPrefixClassification', 'StopWordClassification']
+      }
+    ]
+  },
+  {
+    // Unknown surname
+    confidence: 0.1,
+    Class: PersonClassification,
+    scheme: [
+      {
+        is: ['GivenNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['StopWordClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['AlphaClassification'],
+        not: ['StreetClassification', 'StreetPrefixClassification', 'StopWordClassification']
+      }
+    ]
+  }
+]

--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -57,6 +57,7 @@ class AddressParser extends Parser {
         new WhosOnFirstClassifier(),
 
         // composite classifiers
+        new CompositeClassifier(require('../classifier/scheme/person')),
         new CompositeClassifier(require('../classifier/scheme/street')),
         new CompositeClassifier(require('../classifier/scheme/intersection'))
       ],

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -43,6 +43,26 @@ const testcase = (test, common) => {
   assert('Avenue Aristide Briand', [
     { street: 'Avenue Aristide Briand' }
   ], true)
+
+  assert('Rue Henri Barbusse Paris France', [
+    { street: 'Rue Henri Barbusse' }, { locality: 'Paris' }, { country: 'France' }
+  ], true)
+
+  assert('Rue du Général Leclerc Dunkerque France', [
+    { street: 'Rue du Général Leclerc' }, { locality: 'Dunkerque' }, { country: 'France' }
+  ], true)
+
+  assert('Avenue de Sainte Rose de Lima', [
+    { street: 'Avenue de Sainte Rose de Lima' }
+  ], true)
+
+  assert('Rue du Capitaine Galinat Marseille France', [
+    { street: 'Rue du Capitaine Galinat' }, { locality: 'Marseille' }, { country: 'France' }
+  ], true)
+
+  assert('Rue Jean Baptiste Clément', [
+    { street: 'Rue Jean Baptiste Clément' }
+  ], true)
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
## Supports for

- Compound given names (e.g [`Jean Baptiste Clément`](https://pelias.github.io/compare/#/v1/autocomplete%3Ftext=Rue%20Jean%20Baptiste%20Cl%C3%A9ment))
- Given Name + Surname (e.g Georges Bizet)
- Given Name + stop word + Surname (e.g Maria de Carvalho)
