### PR TITLE
basic support for portuguese addresses

### DIFF
--- a/classification/StreetNameClassification.js
+++ b/classification/StreetNameClassification.js
@@ -1,0 +1,10 @@
+const Classification = require('./Classification')
+
+class StreetNameClassification extends Classification {
+  constructor (confidence, meta) {
+    super(confidence, meta)
+    this.label = 'street_name'
+  }
+}
+
+module.exports = StreetNameClassification

--- a/classification/StreetNameClassification.test.js
+++ b/classification/StreetNameClassification.test.js
@@ -1,0 +1,23 @@
+const Classification = require('./StreetNameClassification')
+
+module.exports.tests = {}
+
+module.exports.tests.constructor = (test) => {
+  test('constructor', (t) => {
+    let c = new Classification()
+    t.equals(c.label, 'street_name')
+    t.equals(c.confidence, 1.0)
+    t.deepEqual(c.meta, {})
+    t.end()
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`StreetNameClassification: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/StopWordClassifier.js
+++ b/classifier/StopWordClassifier.js
@@ -9,7 +9,7 @@ class StopWordsClassifier extends WordClassifier {
   setup () {
     // load stopwords tokens
     this.stopWords = {}
-    libpostal.load(this.stopWords, ['fr', 'de', 'en'], 'stopwords.txt')
+    libpostal.load(this.stopWords, ['fr', 'de', 'en', 'pt'], 'stopwords.txt')
   }
 
   each (span) {

--- a/classifier/StreetPrefixClassifier.js
+++ b/classifier/StreetPrefixClassifier.js
@@ -7,20 +7,13 @@ const libpostal = require('../resources/libpostal/libpostal')
 
 // prefix languages
 // languages which use a street prefix instead of a suffix
-const prefix = ['fr', 'ca', 'es']
+const prefix = ['fr', 'ca', 'es', 'pt']
 
 class StreetPrefixClassifier extends WordClassifier {
   setup () {
     // load street tokens
     this.index = {}
     libpostal.load(this.index, prefix, 'street_types.txt')
-
-    // blacklist any token under 2 chars in length
-    for (let token in this.index) {
-      if (token.length < 2) {
-        delete this.index[token]
-      }
-    }
   }
 
   each (span) {

--- a/classifier/StreetPrefixClassifier.test.js
+++ b/classifier/StreetPrefixClassifier.test.js
@@ -23,9 +23,9 @@ module.exports.tests.contains_numerals = (test) => {
 }
 
 module.exports.tests.single_character_tokens = (test) => {
-  test('index: does not contain single char tokens', (t) => {
+  test('index: does contain single char tokens', (t) => {
     let c = new StreetPrefixClassifier()
-    t.false(Object.keys(c.index).some(token => token.length < 2))
+    t.true(Object.keys(c.index).some(token => token.length < 2))
     t.end()
   })
 }

--- a/classifier/StreetSuffixClassifier.js
+++ b/classifier/StreetSuffixClassifier.js
@@ -7,7 +7,7 @@ const libpostal = require('../resources/libpostal/libpostal')
 
 // prefix languages
 // languages which use a street prefix instead of a suffix
-const prefix = ['fr', 'ca', 'es']
+const prefix = ['fr', 'ca', 'es', 'pt']
 
 class StreetSuffixClassifier extends WordClassifier {
   setup () {

--- a/classifier/scheme/street.js
+++ b/classifier/scheme/street.js
@@ -26,7 +26,7 @@ module.exports = [
         not: ['StreetClassification', 'IntersectionClassification']
       },
       {
-        is: ['AlphaClassification', 'PersonClassification'],
+        is: ['AlphaClassification', 'PersonClassification', 'StreetNameClassification'],
         not: ['StreetClassification', 'IntersectionClassification']
       }
     ]

--- a/classifier/scheme/street_name.js
+++ b/classifier/scheme/street_name.js
@@ -1,0 +1,51 @@
+const StreetNameClassification = require('../../classification/StreetNameClassification')
+
+module.exports = [
+  {
+    // dos Fiéis
+    confidence: 0.5,
+    Class: StreetNameClassification,
+    scheme: [
+      {
+        is: ['StopWordClassification']
+      },
+      {
+        is: ['AlphaClassification', 'PersonClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      }
+    ]
+  },
+  {
+    // Academia das Ciências
+    confidence: 0.5,
+    Class: StreetNameClassification,
+    scheme: [
+      {
+        is: ['AlphaClassification'],
+        not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification']
+      },
+      {
+        is: ['StopWordClassification']
+      },
+      {
+        is: ['AlphaClassification', 'PersonClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      }
+    ]
+  },
+  {
+    // dos Fiéis de Deus
+    confidence: 0.5,
+    Class: StreetNameClassification,
+    scheme: [
+      {
+        is: ['StreetNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['StreetNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      }
+    ]
+  }
+]

--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -58,6 +58,7 @@ class AddressParser extends Parser {
 
         // composite classifiers
         new CompositeClassifier(require('../classifier/scheme/person')),
+        new CompositeClassifier(require('../classifier/scheme/street_name')),
         new CompositeClassifier(require('../classifier/scheme/street')),
         new CompositeClassifier(require('../classifier/scheme/intersection'))
       ],

--- a/test/address.prt.test.js
+++ b/test/address.prt.test.js
@@ -1,0 +1,42 @@
+const AddressParser = require('../parser/AddressParser')
+
+const testcase = (test, common) => {
+  let parser = new AddressParser()
+  let assert = common.assert.bind(null, test, parser)
+
+  assert('Rua Luis de Camoes', [
+    { street: 'Rua Luis de Camoes' }
+  ], true)
+
+  assert('Rua Padre Cruz 31 3060-187 Cantanhede', [
+    { street: 'Rua Padre Cruz' }, { housenumber: '31' },
+    { postcode: '3060-187' }, { locality: 'Cantanhede' }
+  ], true)
+
+  assert('Tv. da Horta 27A', [
+    { street: 'Tv. da Horta' }, { housenumber: '27A' }
+  ], true)
+
+  assert('R Academia das Ciências 17C 1200-030 Lisboa', [
+    { street: 'R Academia das Ciências' }, { housenumber: '17C' },
+    { postcode: '1200-030' }, { region: 'Lisboa' }
+  ], true)
+
+  assert('Rua do Sol a Santa Catarina 17B, 1200-452 Lisboa', [
+    { street: 'Rua do Sol a Santa Catarina' }, { housenumber: '17B' },
+    { postcode: '1200-452' }, { region: 'Lisboa' }
+  ], true)
+
+  assert('Tv. dos Fiéis de Deus 12C Lisboa Portugal', [
+    { street: 'Tv. dos Fiéis de Deus' }, { housenumber: '12C' },
+    { region: 'Lisboa' }, { country: 'Portugal' }
+  ], true)
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`address PRT: ${name}`, testFunction)
+  }
+
+  testcase(test, common)
+}


### PR DESCRIPTION
Here is support for Portuguese addresses.

I added a new classification => `street_name` which should be the part after the street prefix (I'm bad in naming). It's generated by a `CompositeClassifier` and is useful for Portuguese (and French, but not yet refactored).

For now, a street_name can be : 
- Stop Word + Alpha
- Alpha + Stop Word + Alpha
- Street Name + Street Name (for very long street names)

I removed the 2 chars limit from street prefix because a lot of streets in OSM and OA use `R` instead of Rua in Portuguese. I hope this will broke nothing in the future....
