### PR TITLE
Add pelias specific resources for libpostal & WOF

### DIFF
--- a/classifier/StreetSuffixClassifier.js
+++ b/classifier/StreetSuffixClassifier.js
@@ -16,13 +16,6 @@ class StreetSuffixClassifier extends WordClassifier {
     // Exclude french types because they are street prefix
     libpostal.load(this.index, libpostal.languages.filter(e => !prefix.includes(e)), 'street_types.txt')
 
-    // 183 Vista Paku, Pauanui, 3579, New Zealand
-    this.index.paku = true
-
-    // blacklist
-    // this Italian contracted form of Androna causes issues in English
-    delete this.index.and
-
     // blacklist any token under 2 chars in length
     for (let token in this.index) {
       if (token.length < 2) {

--- a/classifier/StreetSuffixClassifier.test.js
+++ b/classifier/StreetSuffixClassifier.test.js
@@ -67,6 +67,32 @@ module.exports.tests.german_suffix = (test) => {
   })
 }
 
+module.exports.tests.valid_pelias_street_types = (test) => {
+  let valid = ['paku']
+
+  valid.forEach(token => {
+    test(`valid pelias street types: ${token}`, (t) => {
+      let s = classify(token)
+      t.deepEqual(s.classifications, {
+        StreetSuffixClassification: new StreetSuffixClassification(token.length > 1 ? 1.0 : 0.2)
+      })
+      t.end()
+    })
+  })
+}
+
+module.exports.tests.invalid_pelias_street_types = (test) => {
+  let invalid = ['and']
+
+  invalid.forEach(token => {
+    test(`invalid pelias street types: ${token}`, (t) => {
+      let s = classify(token)
+      t.deepEqual(s.classifications, {})
+      t.end()
+    })
+  })
+}
+
 module.exports.all = (tape, common) => {
   function test (name, testFunction) {
     return tape(`StreetSuffixClassifier: ${name}`, testFunction)

--- a/classifier/WhosOnFirstClassifier.js
+++ b/classifier/WhosOnFirstClassifier.js
@@ -34,9 +34,7 @@ class WhosOnFirstClassifier extends PhraseClassifier {
     this.tokens = {}
     Object.keys(placetypes).forEach(placetype => {
       this.tokens[placetype] = new Set()
-      placetypes[placetype].files.forEach(file => {
-        whosonfirst.load(this.tokens[placetype], [placetype], file)
-      })
+      whosonfirst.load(this.tokens[placetype], [placetype], placetypes[placetype].files)
 
       // general blacklist
       this.tokens[placetype].delete('north')
@@ -66,16 +64,6 @@ class WhosOnFirstClassifier extends PhraseClassifier {
 
       // placetype specific modifications
       if (placetype === 'locality') {
-        // these are the only two decent values in
-        // file: locality/abrv:eng_x_preferred.txt
-        this.tokens.locality.add('nyc')
-        this.tokens.locality.add('sf')
-
-        // remove problematic locality names
-        this.tokens.locality.delete('texas')
-        this.tokens.locality.delete('california')
-        this.tokens.locality.delete('italy')
-
         // remove locality names that sound like streets
         let remove = ['avenue', 'lane', 'terrace', 'street', 'road', 'crescent']
         this.tokens.locality.forEach(token => {

--- a/classifier/WhosOnFirstClassifier.test.js
+++ b/classifier/WhosOnFirstClassifier.test.js
@@ -45,6 +45,31 @@ module.exports.tests.locality = (test) => {
   })
 }
 
+module.exports.tests.valid_pelias_localities = (test) => {
+  let valid = ['nyc', 'sf']
+
+  valid.forEach(token => {
+    test(`valid pelias locality: ${token}`, (t) => {
+      let s = classify(token)
+      t.true(s.classifications.hasOwnProperty('LocalityClassification'))
+      t.true(s.classifications.hasOwnProperty('AreaClassification'))
+      t.end()
+    })
+  })
+}
+
+module.exports.tests.invalid_pelias_localities = (test) => {
+  let invalid = ['texas', 'california', 'italy']
+
+  invalid.forEach(token => {
+    test(`invalid pelias locality: ${token}`, (t) => {
+      let s = classify(token)
+      t.false(s.classifications.hasOwnProperty('LocalityClassification'))
+      t.end()
+    })
+  })
+}
+
 module.exports.all = (tape, common) => {
   function test (name, testFunction) {
     return tape(`WhosOnFirstClassifier: ${name}`, testFunction)

--- a/resources/libpostal/libpostal.js
+++ b/resources/libpostal/libpostal.js
@@ -1,26 +1,50 @@
 const fs = require('fs')
 const path = require('path')
+const pelias = require('../pelias/pelias')
 const dictPath = path.join(__dirname, `./dictionaries`)
 const allLanguages = fs.readdirSync(dictPath).filter(p => !p.includes('.'))
 
 function load (index, langs, filename, options) {
+  const add = _add(index, options)
+  const remove = _remove(index, options)
+
   langs.forEach(lang => {
     let filepath = path.join(dictPath, lang, filename)
     if (!fs.existsSync(filepath)) { return }
     let dict = fs.readFileSync(filepath, 'utf8')
     dict.split('\n').forEach(row => {
-      row.split('|').forEach(cell => {
-        let value = cell.trim()
-        if (options && options.replace) {
-          value = value.replace(options.replace[0], options.replace[1])
-        }
-        if (options && options.lowercase) {
-          value = value.toLowerCase()
-        }
-        index[value] = true
-      })
+      row.split('|').forEach(add)
     }, this)
   }, this)
+
+  langs.forEach(lang => {
+    pelias.load(path.join('libpostal', lang, filename), add, remove)
+  })
+}
+
+function _normalize (cell, options) {
+  let value = cell.trim()
+  if (options && options.replace) {
+    value = value.replace(options.replace[0], options.replace[1])
+  }
+  if (options && options.lowercase) {
+    value = value.toLowerCase()
+  }
+  return value
+}
+
+function _add (index, options) {
+  return cell => {
+    const value = _normalize(cell, options)
+    index[value] = true
+  }
+}
+
+function _remove (index, options) {
+  return cell => {
+    const value = _normalize(cell, options)
+    delete index[value]
+  }
 }
 
 module.exports.load = load

--- a/resources/pelias/dictionaries/libpostal/en/street_types.txt
+++ b/resources/pelias/dictionaries/libpostal/en/street_types.txt
@@ -1,0 +1,2 @@
+# 183 Vista Paku, Pauanui, 3579, New Zealand
+paku

--- a/resources/pelias/dictionaries/libpostal/it/street_types.txt
+++ b/resources/pelias/dictionaries/libpostal/it/street_types.txt
@@ -1,0 +1,2 @@
+# this Italian contracted form of Androna causes issues in English
+!and

--- a/resources/pelias/dictionaries/whosonfirst/locality/name:eng_x_preferred.txt
+++ b/resources/pelias/dictionaries/whosonfirst/locality/name:eng_x_preferred.txt
@@ -1,0 +1,8 @@
+
+# these are the only two decent values in file: locality/abrv:eng_x_preferred.txt
+nyc
+sf
+# remove problematic locality names
+!texas
+!california
+!italy

--- a/resources/pelias/pelias.js
+++ b/resources/pelias/pelias.js
@@ -1,0 +1,20 @@
+const fs = require('fs')
+const path = require('path')
+const dictPath = path.join(__dirname, `./dictionaries`)
+
+function load (filename, add, remove) {
+  let filepath = path.join(dictPath, filename)
+  if (!fs.existsSync(filepath)) { return }
+  let dict = fs.readFileSync(filepath, 'utf8')
+  dict.split('\n').forEach(row => {
+    if (row.trim().startsWith('#')) {
+      // Do nothing, this is a comment
+    } else if (row.startsWith('!')) {
+      row.substring(1).split('|').forEach(remove)
+    } else {
+      row.split('|').forEach(add)
+    }
+  })
+}
+
+module.exports.load = load


### PR DESCRIPTION
## Features

- We can add pelias custom entries for libpostal and WOF
- It's also possible to blacklist some entries with the character `!` at the beginning of the line
- We can add comments in the file with the character `#` at the beginning of the line
- All resources for libpostal are in `resources/pelias/dictionaries/libpostal` with the same format, i.e `{lang}/{filename}`
- All resources for WOF are in `resources/pelias/dictionaries/whosonfirst` with the same format, i.e `{placetype}/{filename}`
- We load pelias specific entries at the end to ensure that we override old entries (in case of blacklist)