### PR TITLE
remove solutions which dont make logical sense

### DIFF
--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -24,6 +24,7 @@ const WhosOnFirstClassifier = require('../classifier/WhosOnFirstClassifier')
 const ExclusiveCartesianSolver = require('../solver/ExclusiveCartesianSolver')
 const LeadingAreaDeclassifier = require('../solver/LeadingAreaDeclassifier')
 const MultiStreetSolver = require('../solver/MultiStreetSolver')
+const InvalidSolutionFilter = require('../solver/InvalidSolutionFilter')
 const TokenDistanceFilter = require('../solver/TokenDistanceFilter')
 const MustNotPreceedFilter = require('../solver/MustNotPreceedFilter')
 const SubsetFilter = require('../solver/SubsetFilter')
@@ -69,7 +70,20 @@ class AddressParser extends Parser {
         new ExclusiveCartesianSolver(),
         new LeadingAreaDeclassifier(),
         new MultiStreetSolver(),
-        new TokenDistanceFilter(),
+        new SubsetFilter(),
+        new InvalidSolutionFilter([
+          ['HouseNumberClassification', 'LocalityClassification'],
+          ['HouseNumberClassification', 'LocalityClassification', 'RegionClassification'],
+          ['HouseNumberClassification', 'LocalityClassification', 'CountryClassification'],
+          ['HouseNumberClassification', 'LocalityClassification', 'RegionClassification', 'CountryClassification'],
+          ['HouseNumberClassification', 'RegionClassification'],
+          ['HouseNumberClassification', 'RegionClassification', 'CountryClassification'],
+          ['HouseNumberClassification', 'CountryClassification'],
+          ['HouseNumberClassification', 'PostcodeClassification'],
+          ['HouseNumberClassification', 'PostcodeClassification', 'LocalityClassification'],
+          ['HouseNumberClassification', 'PostcodeClassification', 'RegionClassification'],
+          ['HouseNumberClassification', 'PostcodeClassification', 'CountryClassification']
+        ]),
         new MustNotPreceedFilter('PostcodeClassification', 'HouseNumberClassification'),
         new MustNotPreceedFilter('PostcodeClassification', 'StreetClassification'),
         new MustNotPreceedFilter('LocalityClassification', 'HouseNumberClassification'),
@@ -81,6 +95,7 @@ class AddressParser extends Parser {
         new MustNotPreceedFilter('CountryClassification', 'PostcodeClassification'),
         new MustNotPreceedFilter('CountryClassification', 'StreetClassification'),
         new MustNotPreceedFilter('CountryClassification', 'HouseNumberClassification'),
+        new TokenDistanceFilter(),
         new SubsetFilter()
       ],
       options

--- a/solver/InvalidSolutionFilter.js
+++ b/solver/InvalidSolutionFilter.js
@@ -1,0 +1,26 @@
+/**
+ * enforce that certain combinations of classifications
+ * dont logically make sense are removed.
+ *
+ * eg. remove solutions which are only 'housenumber+locality'
+ *
+ * if a solution EXACTLY matching a $pattern then it will be removed.
+ */
+class InvalidSolutionFilter {
+  constructor (patterns) {
+    this.patterns = (Array.isArray(patterns) ? patterns : [])
+    this.patterns.map(p => p.sort()) // sort alphabetically
+  }
+  solve (tokenizer) {
+    tokenizer.solution = tokenizer.solution.filter(s => {
+      // sort alphabetically
+      let classifications = s.pair.map(p => p.classification.constructor.name).sort()
+      return !this.patterns.some(p => {
+        if (classifications.length !== p.length) { return false }
+        return classifications.every((_, i) => classifications[i] === p[i])
+      })
+    }, this)
+  }
+}
+
+module.exports = InvalidSolutionFilter

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -69,6 +69,16 @@ const testcase = (test, common) => {
   assert('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }], true)
   assert('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }], true)
   assert('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }], true)
+
+  // invalid solutions (because the classification pairings dont make sense logically)
+  assert('1 San Francisco', [])
+  assert('1 California', [])
+  assert('1 USA', [])
+  assert('1 San Francisco California', [])
+  assert('1 San Francisco USA', [])
+  assert('1 San Francisco California USA', [])
+  assert('1 California USA', [])
+  assert('1 90210', [])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
this new solution filter removes any combinations of classifications deemed 'invalid'.

for example, a result of `[{ housenumber: '10'}, { city: 'Berlin' }]` doesn't make sense logically because the two classifications have no logical reason to be grouped together.

the filter is extensible to allow other combinations to be removed in the future.