### PR TITLE
support for parsing transit stop ids

### DIFF
--- a/classifier/scheme/place.js
+++ b/classifier/scheme/place.js
@@ -64,5 +64,20 @@ module.exports = [
         not: []
       }
     ]
+  },
+  {
+    // Stop 10792
+    confidence: 0.8,
+    Class: PlaceClassification,
+    scheme: [
+      {
+        is: ['PlaceClassification'],
+        not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification']
+      },
+      {
+        is: ['NumericClassification'],
+        not: []
+      }
+    ]
   }
 ]

--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -84,7 +84,9 @@ class AddressParser extends Parser {
           ['HouseNumberClassification', 'PostcodeClassification'],
           ['HouseNumberClassification', 'PostcodeClassification', 'LocalityClassification'],
           ['HouseNumberClassification', 'PostcodeClassification', 'RegionClassification'],
-          ['HouseNumberClassification', 'PostcodeClassification', 'CountryClassification']
+          ['HouseNumberClassification', 'PostcodeClassification', 'CountryClassification'],
+          ['PlaceClassification', 'HouseNumberClassification'],
+          ['PlaceClassification', 'PostcodeClassification']
         ]),
         new MustNotFollowFilter('PlaceClassification', 'HouseNumberClassification'),
         new MustNotFollowFilter('PlaceClassification', 'StreetClassification'),

--- a/resources/pelias/dictionaries/libpostal/en/place_names.txt
+++ b/resources/pelias/dictionaries/libpostal/en/place_names.txt
@@ -1,1 +1,4 @@
 temple
+cathedral
+stop
+!dist

--- a/resources/pelias/dictionaries/whosonfirst/locality/name:eng_x_preferred.txt
+++ b/resources/pelias/dictionaries/whosonfirst/locality/name:eng_x_preferred.txt
@@ -8,6 +8,7 @@ sf
 !university
 !hospital
 !temple
+!cathedral
 !airport
 !deli
 !us

--- a/test/transit.test.js
+++ b/test/transit.test.js
@@ -1,0 +1,22 @@
+const AddressParser = require('../parser/AddressParser')
+
+const testcase = (test, common) => {
+  let parser = new AddressParser()
+  let assert = common.assert.bind(null, test, parser)
+
+  assert('Stop 1', [
+    { place: 'Stop 1' }
+  ], true)
+
+  assert('Stop 10010', [
+    { place: 'Stop 10010' }
+  ], true)
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`Transit: ${name}`, testFunction)
+  }
+
+  testcase(test, common)
+}


### PR DESCRIPTION
this PR adds support for parsing stop ids such as `stop 11101`.

also squeezed in this PR some dictionary updates which I had accumulated from testing 🤷‍♂ 