### PR TITLE
various bugfixes

### DIFF
--- a/classification/PunctuationClassification.js
+++ b/classification/PunctuationClassification.js
@@ -1,0 +1,10 @@
+const Classification = require('../classification/Classification')
+
+class PunctuationClassification extends Classification {
+  constructor (confidence, meta) {
+    super(confidence, meta)
+    this.label = 'punctuation'
+  }
+}
+
+module.exports = PunctuationClassification

--- a/classification/PunctuationClassification.test.js
+++ b/classification/PunctuationClassification.test.js
@@ -1,0 +1,24 @@
+const Classification = require('./PunctuationClassification')
+
+module.exports.tests = {}
+
+module.exports.tests.constructor = (test) => {
+  test('constructor', (t) => {
+    let c = new Classification()
+    t.false(c.public)
+    t.equals(c.label, 'punctuation')
+    t.equals(c.confidence, 1.0)
+    t.deepEqual(c.meta, {})
+    t.end()
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`PunctuationClassification: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/AlphaNumericClassifier.js
+++ b/classifier/AlphaNumericClassifier.js
@@ -2,15 +2,18 @@ const WordClassifier = require('./super/WordClassifier')
 const AlphaClassification = require('../classification/AlphaClassification')
 const NumericClassification = require('../classification/NumericClassification')
 const AlphaNumericClassification = require('../classification/AlphaNumericClassification')
+const PunctuationClassification = require('../classification/PunctuationClassification')
 
 class AlphaNumericClassifier extends WordClassifier {
   each (span) {
-    if (!span.contains.numerals) {
-      span.classify(new AlphaClassification(1))
-    } else if (/^\d+$/.test(span.norm)) {
+    if (/^\d+$/.test(span.norm)) {
       span.classify(new NumericClassification(1))
-    } else {
+    } else if (span.contains.numerals) {
       span.classify(new AlphaNumericClassification(1))
+    } else if (/^[@&/\\#,+()$~%.!^'";:*?[\]<>{}]+$/.test(span.norm)) {
+      span.classify(new PunctuationClassification(1))
+    } else {
+      span.classify(new AlphaClassification(1))
     }
   }
 }

--- a/classifier/AlphaNumericClassifier.test.js
+++ b/classifier/AlphaNumericClassifier.test.js
@@ -2,6 +2,7 @@ const AlphaNumericClassifier = require('./AlphaNumericClassifier')
 const AlphaClassification = require('../classification/AlphaClassification')
 const NumericClassification = require('../classification/NumericClassification')
 const AlphaNumericClassification = require('../classification/AlphaNumericClassification')
+const PunctuationClassification = require('../classification/PunctuationClassification')
 const Span = require('../tokenization/Span')
 
 module.exports.tests = {}
@@ -50,6 +51,19 @@ module.exports.tests.numeric = (test) => {
   test('NumericClassification: multiple digits', (t) => {
     let s = classify('1234567890')
     t.deepEqual(s.classifications, { NumericClassification: new NumericClassification(1.0) })
+    t.end()
+  })
+}
+
+module.exports.tests.punctuation = (test) => {
+  test('PunctuationClassification: single char', (t) => {
+    let s = classify('@')
+    t.deepEqual(s.classifications, { PunctuationClassification: new PunctuationClassification(1.0) })
+    t.end()
+  })
+  test('PunctuationClassification: multiple chars', (t) => {
+    let s = classify('###&$%')
+    t.deepEqual(s.classifications, { PunctuationClassification: new PunctuationClassification(1.0) })
     t.end()
   })
 }

--- a/classifier/IntersectionClassifier.js
+++ b/classifier/IntersectionClassifier.js
@@ -1,22 +1,30 @@
 const PhraseClassifier = require('./super/PhraseClassifier')
 const IntersectionClassification = require('../classification/IntersectionClassification')
-const libpostal = require('../resources/libpostal/libpostal')
+// const libpostal = require('../resources/libpostal/libpostal')
 
 // dictionaries sourced from the libpostal project
 // see: https://github.com/openvenues/libpostal
 
-const languages = libpostal.languages
+// const languages = libpostal.languages
 
 class IntersectionClassifier extends PhraseClassifier {
   setup () {
     this.index = {}
 
     // remove single characters but keep some punctuation
-    let options = { replace: [/^[^&@]{1}$/, ''] }
-    libpostal.load(this.index, languages, 'cross_streets.txt', options)
+    // let options = { replace: [/^[^&@]{1}$/, ''] }
+    // libpostal.load(this.index, languages, 'cross_streets.txt', options)
 
     // blacklist
-    delete this.index.corner
+    // delete this.index.corner
+
+    this.index['&'] = true
+    this.index.and = true
+    this.index.und = true
+    this.index['@'] = true
+    this.index.at = true
+    this.index.con = true
+    this.index['an der ecke von'] = true
   }
 
   each (span) {

--- a/classifier/scheme/place.js
+++ b/classifier/scheme/place.js
@@ -66,6 +66,21 @@ module.exports = [
     ]
   },
   {
+    // National Air & Space Museum
+    confidence: 0.8,
+    Class: PlaceClassification,
+    scheme: [
+      {
+        is: ['AlphaClassification'],
+        not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification']
+      },
+      {
+        is: ['PlaceClassification'],
+        not: []
+      }
+    ]
+  },
+  {
     // Stop 10792
     confidence: 0.8,
     Class: PlaceClassification,

--- a/classifier/scheme/street_name.js
+++ b/classifier/scheme/street_name.js
@@ -11,7 +11,7 @@ module.exports = [
       },
       {
         is: ['AlphaClassification', 'PersonClassification'],
-        not: ['StreetClassification', 'IntersectionClassification']
+        not: ['StreetClassification', 'IntersectionClassification', 'StreetSuffixClassification']
       }
     ]
   },
@@ -22,14 +22,14 @@ module.exports = [
     scheme: [
       {
         is: ['AlphaClassification'],
-        not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification']
+        not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification', 'StreetPrefixClassification']
       },
       {
         is: ['StopWordClassification']
       },
       {
         is: ['AlphaClassification', 'PersonClassification'],
-        not: ['StreetClassification', 'IntersectionClassification']
+        not: ['StreetClassification', 'IntersectionClassification', 'StreetSuffixClassification']
       }
     ]
   },

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -11,6 +11,16 @@ const testcase = (test, common) => {
   assert('Martin Luther King Blvd.', [
     { street: 'Martin Luther King Blvd.' }
   ], true)
+
+  assert('1900 SE A ST, SAN FRANCISCO', [
+    { housenumber: '1900' }, { street: 'SE A ST' },
+    { locality: 'SAN FRANCISCO' }
+  ], true)
+
+  assert('1900 SE F ST, SAN FRANCISCO', [
+    { housenumber: '1900' }, { street: 'SE F ST' },
+    { locality: 'SAN FRANCISCO' }
+  ], true)
 }
 
 module.exports.all = (tape, common) => {

--- a/test/intersection.test.js
+++ b/test/intersection.test.js
@@ -5,9 +5,14 @@ const testcase = (test, common) => {
   let assert = common.assert.bind(null, test, parser)
 
   // intersection queries
-  assert('Corner of Main St & Second Ave', [
-    { street: 'Main St' }, { street: 'Second Ave' }
-  ], true)
+
+  // intersection tokens as a prefix are currently unsupported
+  // assert('Corner of Main St & Second Ave', [
+  //   { street: 'Main St' }, { street: 'Second Ave' }
+  // ], true)
+  // assert('cnr west st and north ave', [
+  //   { street: 'west st' }, { street: 'north ave' }
+  // ], true)
 
   assert('Main St & Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
@@ -25,13 +30,23 @@ const testcase = (test, common) => {
     { street: 'Gleimstraße' }, { street: 'Schönhauserallee' }
   ], true)
 
-  assert('cnr west st and north ave', [
-    { street: 'west st' }, { street: 'north ave' }
-  ], true)
-
   // should not consider intersection tokens for street name
   assert('& b', [])
+  assert('@ b', [])
+  assert('at b', [])
   assert('a &', [])
+  assert('a @', [])
+  assert('a at', [])
+  assert('& street', [])
+  assert('@ street', [])
+  assert('carrer &', [])
+  assert('carrer @', [])
+
+  // should correctly parse street names containing an intersection token
+  assert('at street', [{ street: 'at street' }], true)
+  assert('corner street', [{ street: 'corner street' }], true)
+  assert('carrer en', [{ street: 'carrer en' }], true)
+  assert('carrer con', [{ street: 'carrer con' }], true)
 
   // no street suffix
   assert('foo & bar', [
@@ -97,9 +112,9 @@ const testcase = (test, common) => {
   // assert('University of Hawaii at Hilo', [
   //   { street: 'SW 6th' }, { street: 'Pine' }
   // ], true)
-  // assert('national air and space museum', [
-  //   { street: 'SW 6th' }, { street: 'Pine' }
-  // ], true)
+  assert('national air and space museum', [
+    { place: 'national air and space museum' }
+  ], true)
 
   // Trimet syntax
   // assert('9,Lambert', [


### PR DESCRIPTION
- add punctuation classification (as distinct from alphanumeric or alpha), so you can't have `& street`
- ~~remove single character intersection tokens to make matching stricter, still allowing some single digit punctuation chars~~
- remove all but the most necessary intersection tokens
- do not classify intersections when the intersection delimiter (such as 'at' or '@') does not have tokens on either side. (note, this means queries like 'corner of..' no longer work)
- improved place classification
- additional test cases

resolves https://github.com/pelias/parser/issues/34