### PR TITLE
stricter_postcodes

### DIFF
--- a/classifier/PostcodeClassifier.js
+++ b/classifier/PostcodeClassifier.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+// const fs = require('fs')
 const path = require('path')
 const WordClassifier = require('./super/WordClassifier')
 const PostcodeClassification = require('../classification/PostcodeClassification')
@@ -7,14 +7,15 @@ const dictPath = path.join(__dirname, `../resources/chromium-i18n/ssl-address`)
 // postcode data sourced from google-i18n project
 // see: https://chromium-i18n.appspot.com/ssl-address
 // note: reducing the list of country codes will have a performance benefit
-const countryCodes = fs.readdirSync(dictPath)
-  .filter(p => p.endsWith('.json'))
-  .map(p => p.split('.')[0])
+// const countryCodes = fs.readdirSync(dictPath)
+//   .filter(p => p.endsWith('.json'))
+//   .map(p => p.split('.')[0])
+const countryCodes = ['us', 'gb', 'fr', 'de', 'es', 'pt', 'au', 'nz', 'kr', 'jp', 'in', 'ru']
 
 class PostcodeClassifier extends WordClassifier {
   setup () {
     this.data = countryCodes.map(cc => {
-      let row = require(path.join(dictPath, `${cc}.json`))
+      let row = require(path.join(dictPath, `${cc.toUpperCase()}.json`))
       row.regex = new RegExp('^(' + row.zip + ')$', 'i')
       return row
     }).filter(row => !row.regex.test('100')) // remove countries with 3-digit postcodes
@@ -24,6 +25,14 @@ class PostcodeClassifier extends WordClassifier {
     // skip spans which do not contain numbers
     // @todo: is this correct globally?
     if (!span.contains.numerals) { return }
+
+    // do not allow postcode in the star position unless it is the
+    // only token present.
+    if (
+      span.classifications.hasOwnProperty('StartTokenClassification') &&
+      !span.classifications.hasOwnProperty('EndTokenClassification')) {
+      return
+    }
 
     for (let i = 0; i < this.data.length; i++) {
       if (this.data[i].regex.test(span.norm)) {

--- a/classifier/PostcodeClassifier.js
+++ b/classifier/PostcodeClassifier.js
@@ -26,11 +26,12 @@ class PostcodeClassifier extends WordClassifier {
     // @todo: is this correct globally?
     if (!span.contains.numerals) { return }
 
-    // do not allow postcode in the star position unless it is the
-    // only token present.
+    // do not allow postcode in the start position unless it is the
+    // only token present in its section
     if (
       span.classifications.hasOwnProperty('StartTokenClassification') &&
-      !span.classifications.hasOwnProperty('EndTokenClassification')) {
+      (span.graph.length('prev') > 0 || span.graph.length('next') > 0)
+    ) {
       return
     }
 

--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -1,0 +1,19 @@
+const AddressParser = require('../parser/AddressParser')
+
+const testcase = (test, common) => {
+  let parser = new AddressParser()
+  let assert = common.assert.bind(null, test, parser)
+
+  assert('6000, NSW, Australia', [
+    { postcode: '6000' },
+    { region: 'NSW' }, { country: 'Australia' }
+  ], true)
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`address AUS: ${name}`, testFunction)
+  }
+
+  testcase(test, common)
+}

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -25,6 +25,9 @@ const testcase = (test, common) => {
   // postcode allowed in first position when only 1 token
   assert('90210', [{ postcode: '90210' }], true)
 
+  // postcode allowed in first position when only 1 token in section
+  assert('90210, CA', [{ postcode: '90210' }, { region: 'CA' }], true)
+
   // postcode not allowed in first position otherwise
   assert('90210 Foo', [])
 }

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -21,6 +21,12 @@ const testcase = (test, common) => {
     { housenumber: '1900' }, { street: 'SE F ST' },
     { locality: 'SAN FRANCISCO' }
   ], true)
+
+  // postcode allowed in first position when only 1 token
+  assert('90210', [{ postcode: '90210' }], true)
+
+  // postcode not allowed in first position otherwise
+  assert('90210 Foo', [])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
enforce stricter postcode parsing:
- reduce the number of country codes we load (feel free to add more)
- do not allow postcode in the first position unless its the only token.

this greatly improves autocomplete parsing of addresses with high housenumbers (>1000)