### PR TITLE
autocomplete jitter fixes

### DIFF
--- a/classifier/scheme/street.js
+++ b/classifier/scheme/street.js
@@ -304,21 +304,6 @@ module.exports = [
     ]
   },
   {
-    // West Main Street
-    confidence: 0.84,
-    Class: StreetClassification,
-    scheme: [
-      {
-        is: ['DirectionalClassification'],
-        not: ['StreetClassification', 'IntersectionClassification']
-      },
-      {
-        is: ['StreetClassification'],
-        not: ['DirectionalClassification']
-      }
-    ]
-  },
-  {
     // Main Street West
     confidence: 0.88,
     Class: StreetClassification,

--- a/classifier/scheme/street_name.js
+++ b/classifier/scheme/street_name.js
@@ -7,7 +7,8 @@ module.exports = [
     Class: StreetNameClassification,
     scheme: [
       {
-        is: ['StopWordClassification']
+        is: ['StopWordClassification'],
+        not: ['DirectionalClassification']
       },
       {
         is: ['AlphaClassification', 'PersonClassification'],
@@ -25,7 +26,8 @@ module.exports = [
         not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification', 'StreetPrefixClassification']
       },
       {
-        is: ['StopWordClassification']
+        is: ['StopWordClassification'],
+        not: ['DirectionalClassification']
       },
       {
         is: ['AlphaClassification', 'PersonClassification'],

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -30,6 +30,24 @@ const testcase = (test, common) => {
 
   // postcode not allowed in first position otherwise
   assert('90210 Foo', [])
+
+  // autocomplete street name jitter
+  // note: we are only testing the street name stays the same throughout
+  assert('N FISKE AVE', [{ street: 'N FISKE AVE' }], true)
+  assert('N FISKE AVE P', [{ street: 'N FISKE AVE' }], true)
+  assert('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }], true)
+  assert('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }], true)
+  assert('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }], true)
+  assert('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }], true)
+  assert('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }], true)
+  assert('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }], true)
+  assert('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }], true)
+  assert('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }], true)
+  assert('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }], true)
+  assert('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }], true)
+  assert('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }], true)
+  assert('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }], true)
+  assert('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }], true)
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
improved parser to avoid autocomplete jitter issues

I made two significant changes to the `CompositeClassifier`:
- reorder tokens so that they are classified from the shortest phrase to longest phrase, making it easier to 'extend' classifications
- avoid adding tokens to the front of a street classification that begins with a street prefix (eg. 'A + Ave B')