### PR TITLE
Various FRA improvements

### DIFF
--- a/classifier/scheme/street_name.js
+++ b/classifier/scheme/street_name.js
@@ -36,6 +36,24 @@ module.exports = [
     ]
   },
   {
+    // du 4 septembre
+    confidence: 0.5,
+    Class: StreetNameClassification,
+    scheme: [
+      {
+        is: ['StopWordClassification']
+      },
+      {
+        is: ['NumericClassification'],
+        not: ['PostcodeClassification']
+      },
+      {
+        is: ['AlphaClassification'],
+        not: ['StreetClassification', 'IntersectionClassification', 'LocalityClassification']
+      }
+    ]
+  },
+  {
     // dos Fiéis de Deus
     confidence: 0.5,
     Class: StreetNameClassification,

--- a/resources/pelias/dictionaries/libpostal/fr/street_types.txt
+++ b/resources/pelias/dictionaries/libpostal/fr/street_types.txt
@@ -1,0 +1,2 @@
+cité|cite
+cités|cites

--- a/resources/pelias/dictionaries/whosonfirst/region/name:eng_x_preferred.txt
+++ b/resources/pelias/dictionaries/whosonfirst/region/name:eng_x_preferred.txt
@@ -1,0 +1,2 @@
+# This is not used as region
+!paris

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -79,6 +79,18 @@ const testcase = (test, common) => {
   assert('Mery-Sur-Oise', [
     { locality: 'Mery-Sur-Oise' }
   ], true)
+
+  assert('4 Cité Du Cardinal Lemoine 75005 Paris', [
+    { housenumber: '4' }, { street: 'Cité Du Cardinal Lemoine' }, { postcode: '75005' }, { locality: 'Paris' }
+  ], true)
+
+  assert('32 Rue Du 4 Septembre', [
+    { housenumber: '32' }, { street: 'Rue Du 4 Septembre' }
+  ], true)
+
+  assert('12 Cité Roland Garros', [
+    { housenumber: '12' }, { street: 'Cité Roland Garros' }
+  ], true)
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
Cité and Cités where missing in street types, I added them.

Paris is a complex city, it's known as region and locality but when we are searching for Paris, it should be only as a locality. That's why we should classified it only as locality.

Add Street name with number such as `Rue du 4 septembre`.
In fact there are a lot of streets named like dates eg 
- `Rue du 8 Mai 1945`
- `Rue du 4 Septembre`
- `Place Du 11 Novembre 1945`

This PR doesn't classify all these streets, maybe we should add a special classification for full date.