### PR TITLE
Handle SIGTERM event and add test/oa in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,6 @@ resources/whosonfirst/dictionaries/*/*.txt
 !resources/whosonfirst/dictionaries/region/name:eng_x_preferred.txt
 !resources/whosonfirst/dictionaries/region/abrv:eng_x_preferred.txt
 !resources/whosonfirst/dictionaries/locality/name:eng_x_preferred.txt
+
+# ignore any openaddresses test cases
+test/oa


### PR DESCRIPTION
Only master can handle `SIGTERM` signals and I use `process.exit` because the close function is only returned by the listen function.

resolves #35 