### PR TITLE
Add more place classification

### DIFF
--- a/classifier/WhosOnFirstClassifier.js
+++ b/classifier/WhosOnFirstClassifier.js
@@ -82,15 +82,16 @@ class WhosOnFirstClassifier extends PhraseClassifier {
   }
 
   each (span) {
-    // do not classify tokens preceeded by an 'IntersectionClassification' or 'StopWordClassification'
+    let confidence = 1.0
+    // do not classify tokens preceeded by an 'IntersectionClassification' or add a penality to 'StopWordClassification'
     let firstChild = span.graph.findOne('child:first') || span
     let prev = firstChild.graph.findOne('prev')
-    if (
-      prev && (
-        prev.classifications.hasOwnProperty('IntersectionClassification') ||
-        prev.classifications.hasOwnProperty('StopWordClassification')
-      )) {
-      return
+    if (prev) {
+      if (prev.classifications.hasOwnProperty('IntersectionClassification')) {
+        return
+      } else if (prev.classifications.hasOwnProperty('StopWordClassification')) {
+        confidence = confidence / 2
+      }
     }
 
     // do not classify tokens preceeding 'StreetSuffixClassification' or 'PlaceClassification'
@@ -116,7 +117,7 @@ class WhosOnFirstClassifier extends PhraseClassifier {
         ) { return }
 
         // classify tokens
-        placetypes[placetype].classifications.forEach(Class => span.classify(new Class()))
+        placetypes[placetype].classifications.forEach(Class => span.classify(new Class(confidence)))
       }
     })
   }

--- a/classifier/scheme/place.js
+++ b/classifier/scheme/place.js
@@ -94,5 +94,39 @@ module.exports = [
         not: []
       }
     ]
+  },
+  {
+    // University of Somewhere
+    confidence: 0.8,
+    Class: PlaceClassification,
+    scheme: [
+      {
+        is: ['PlaceClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['StopWordClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['AreaClassification'],
+        not: ['StreetClassification']
+      }
+    ]
+  },
+  {
+    // Ecole Jules Vernes
+    confidence: 0.8,
+    Class: PlaceClassification,
+    scheme: [
+      {
+        is: ['PlaceClassification'],
+        not: ['StreetClassification']
+      },
+      {
+        is: ['PersonClassification'],
+        not: ['StreetClassification']
+      }
+    ]
   }
 ]

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -88,6 +88,18 @@ const testcase = (test, common) => {
   assert('12 Cité Roland Garros', [
     { housenumber: '12' }, { street: 'Cité Roland Garros' }
   ])
+
+  assert('École Paul Valéry Montpellier', [
+    { place: 'École Paul Valéry' }, { locality: 'Montpellier' }
+  ])
+
+  assert('Université de Montpellier', [
+    { place: 'Université de Montpellier' }
+  ])
+
+  assert('École Jules Vernes Villetaneuse', [
+    { place: 'École Jules Vernes' }, { locality: 'Villetaneuse' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -45,6 +45,12 @@ const testcase = (test, common) => {
   assert('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
   assert('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
   assert('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
+
+  assert('University of Hawaii', [{ place: 'University of Hawaii' }])
+
+  assert('University of Hawaii at Hilo', [
+    { place: 'University of Hawaii' }, { street: 'Hilo' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -48,9 +48,11 @@ const testcase = (test, common) => {
 
   assert('University of Hawaii', [{ place: 'University of Hawaii' }])
 
-  assert('University of Hawaii at Hilo', [
-    { place: 'University of Hawaii' }, { street: 'Hilo' }
-  ])
+  // Maybe one day this test will pass...
+  // see: https://github.com/pelias/parser/pull/49
+  // assert('University of Hawaii at Hilo', [
+  //   { place: 'University of Hawaii at Hilo' }
+  // ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
## Background

When I tried a acceptance test on the API with the pelias_parser branch, I found some regressions. One of them was `University of Hawaii at Hilo`. I found that this was not classified as place, so I tried to added it.

In my first try, I added the correct classification in `classifier/scheme/place.js` but nothing happend. So I investigate a bit more and I found an exception on span containing a `StopWordClassification` in the `WhosOnFirstClassifier`.

## What to do next ?

In order to limit the side effects, I preferred to add a penalty instead of completely removing this exception. With this, no test fails.

The parsing of `University of Hawaii at Hilo` is not at 100% correct, but it's better :)

If I completely remove the exception, 2 tests are failing, `Rue de Paris` and `Avenue de Sainte Rose de Lima` which should be streets.

I put this in standby at the moment in case it is necessary to keep the exception.
I am open to discussion / review :smile: 