### PR TITLE
intersections bug fix

### DIFF
--- a/classifier/CompositeClassifier.js
+++ b/classifier/CompositeClassifier.js
@@ -52,6 +52,7 @@ class CompositeClassifier extends SectionClassifier {
     let phrases = section.graph.findAll('phrase')
 
     // sort phrases so shorter phrases are matched first
+    // note: this mutates the original array
     phrases.sort((a, b) => a.norm.length - b.norm.length)
 
     this.schemes.forEach(s => {

--- a/classifier/scheme/intersection.js
+++ b/classifier/scheme/intersection.js
@@ -33,7 +33,7 @@ module.exports = [
       {
         is: ['AlphaClassification', 'NumericClassification', 'OrdinalClassification'],
         not: ['IntersectionClassification', 'StreetSuffixClassification'],
-        confidence: 0.51,
+        confidence: 0.81,
         Class: StreetClassification
       },
       {
@@ -43,7 +43,7 @@ module.exports = [
       {
         is: ['AlphaClassification', 'NumericClassification', 'OrdinalClassification'],
         not: ['IntersectionClassification'],
-        confidence: 0.52,
+        confidence: 0.82,
         Class: StreetClassification
       }
     ]

--- a/test/intersection.test.js
+++ b/test/intersection.test.js
@@ -108,6 +108,14 @@ const testcase = (test, common) => {
     { street: 'SW 6th' }, { street: 'Pine' }
   ], true)
 
+  assert('9th and Lambert', [
+    { street: '9th' }, { street: 'Lambert' }
+  ], true)
+
+  assert('filbert & 32nd', [
+    { street: 'filbert' }, { street: '32nd' }
+  ], true)
+
   // Should not detect this as an intersection
   // assert('University of Hawaii at Hilo', [
   //   { street: 'SW 6th' }, { street: 'Pine' }


### PR DESCRIPTION
This PR fixes two bugs with intersection parsing:
- favour longer street names over shorter substrings
- do not try to 'patch' existing solutions by adding missing fields, instead simply append new solutions for `multimatch` classifications

I've also increased the confidence in the `Foo St and Bar St` type classification because it's likely a good quality match