### PR TITLE
refactor test runner

### DIFF
--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -4,7 +4,7 @@ const testcase = (test, common) => {
   assert('6000, NSW, Australia', [
     { postcode: '6000' },
     { region: 'NSW' }, { country: 'Australia' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('6000, NSW, Australia', [
     { postcode: '6000' },

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Am Falkpl. 5, 10437 Berlin', [
     { street: 'Am Falkpl.' }, { housenumber: '5' },

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -4,18 +4,18 @@ const testcase = (test, common) => {
   assert('Am Falkpl. 5, 10437 Berlin', [
     { street: 'Am Falkpl.' }, { housenumber: '5' },
     { postcode: '10437' }, { locality: 'Berlin' }
-  ], true)
+  ])
 
   assert('Am Bürgerpark 15-18, 13156, Berlin', [
     { street: 'Am Bürgerpark' }, { housenumber: '15-18' },
     { postcode: '13156' }, { locality: 'Berlin' }
-  ], true)
+  ])
 
   assert('Kaschk Bar, Linienstraße 40 10119 Berlin', [
     { place: 'Kaschk Bar' },
     { street: 'Linienstraße' }, { housenumber: '40' },
     { postcode: '10119' }, { locality: 'Berlin' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.esp.test.js
+++ b/test/address.esp.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Carrer d\'Aragó 155 08011 Barcelona', [
     { street: 'Carrer d\'Aragó' }, { housenumber: '155' },

--- a/test/address.esp.test.js
+++ b/test/address.esp.test.js
@@ -4,7 +4,7 @@ const testcase = (test, common) => {
   assert('Carrer d\'Aragó 155 08011 Barcelona', [
     { street: 'Carrer d\'Aragó' }, { housenumber: '155' },
     { postcode: '08011' }, { locality: 'Barcelona' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Rue Montmartre', [
     { street: 'Rue Montmartre' }

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -3,91 +3,91 @@ const testcase = (test, common) => {
 
   assert('Rue Montmartre', [
     { street: 'Rue Montmartre' }
-  ], true)
+  ])
 
   assert('123 Rue Montmartre, Paris', [
     { housenumber: '123' }, { street: 'Rue Montmartre' }, { locality: 'Paris' }
-  ], true)
+  ])
 
   assert('Rue de Paris', [
     { street: 'Rue de Paris' }
-  ], true)
+  ])
 
   assert('Rue de la Paix', [
     { street: 'Rue de la Paix' }
-  ], true)
+  ])
 
   assert('Boulevard du Général Charles De Gaulle', [
     { street: 'Boulevard du Général Charles De Gaulle' }
-  ], true)
+  ])
 
   assert('11 Boulevard Saint Germains', [
     { housenumber: '11' }, { street: 'Boulevard Saint Germains' }
-  ], true)
+  ])
 
   assert('Rue Saint Anne', [
     { street: 'Rue Saint Anne' }
-  ], true)
+  ])
 
   assert('Boulevard Charles De Gaulle', [
     { street: 'Boulevard Charles De Gaulle' }
-  ], true)
+  ])
 
   assert('Allée Victor Hugo', [
     { street: 'Allée Victor Hugo' }
-  ], true)
+  ])
 
   assert('Avenue Aristide Briand', [
     { street: 'Avenue Aristide Briand' }
-  ], true)
+  ])
 
   assert('Rue Henri Barbusse Paris France', [
     { street: 'Rue Henri Barbusse' }, { locality: 'Paris' }, { country: 'France' }
-  ], true)
+  ])
 
   assert('Rue du Général Leclerc Dunkerque France', [
     { street: 'Rue du Général Leclerc' }, { locality: 'Dunkerque' }, { country: 'France' }
-  ], true)
+  ])
 
   assert('Avenue de Sainte Rose de Lima', [
     { street: 'Avenue de Sainte Rose de Lima' }
-  ], true)
+  ])
 
   assert('Rue du Capitaine Galinat Marseille France', [
     { street: 'Rue du Capitaine Galinat' }, { locality: 'Marseille' }, { country: 'France' }
-  ], true)
+  ])
 
   assert('Rue Jean Baptiste Clément', [
     { street: 'Rue Jean Baptiste Clément' }
-  ], true)
+  ])
 
   assert('Mery Sur Oise', [
     { locality: 'Mery Sur Oise' }
-  ], true)
+  ])
 
   assert('Méry Sur Oise', [
     { locality: 'Méry Sur Oise' }
-  ], true)
+  ])
 
   assert('Méry-Sur-Oise', [
     { locality: 'Méry-Sur-Oise' }
-  ], true)
+  ])
 
   assert('Mery-Sur-Oise', [
     { locality: 'Mery-Sur-Oise' }
-  ], true)
+  ])
 
   assert('4 Cité Du Cardinal Lemoine 75005 Paris', [
     { housenumber: '4' }, { street: 'Cité Du Cardinal Lemoine' }, { postcode: '75005' }, { locality: 'Paris' }
-  ], true)
+  ])
 
   assert('32 Rue Du 4 Septembre', [
     { housenumber: '32' }, { street: 'Rue Du 4 Septembre' }
-  ], true)
+  ])
 
   assert('12 Cité Roland Garros', [
     { housenumber: '12' }, { street: 'Cité Roland Garros' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.gbr.test.js
+++ b/test/address.gbr.test.js
@@ -3,7 +3,7 @@ const testcase = (test, common) => {
 
   assert('Rushendon Furlong', [
     { street: 'Rushendon Furlong' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.gbr.test.js
+++ b/test/address.gbr.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Rushendon Furlong', [
     { street: 'Rushendon Furlong' }

--- a/test/address.ind.test.js
+++ b/test/address.ind.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('100, Mahalakshmi Rd, Ganesh Nagar, Kirti Nagar, New Sanghavi, Pimpri-Chinchwad, Maharashtra 411027', [
     { housenumber: '100' }, { street: 'Mahalakshmi Rd' },

--- a/test/address.ind.test.js
+++ b/test/address.ind.test.js
@@ -5,7 +5,7 @@ const testcase = (test, common) => {
     { housenumber: '100' }, { street: 'Mahalakshmi Rd' },
     { locality: 'Pimpri-Chinchwad' }, { region: 'Maharashtra' },
     { postcode: '411027' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Julianastraat, Heel', [
     { street: 'Julianastraat' }, { locality: 'Heel' }

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -3,15 +3,15 @@ const testcase = (test, common) => {
 
   assert('Julianastraat, Heel', [
     { street: 'Julianastraat' }, { locality: 'Heel' }
-  ], true)
+  ])
 
   assert('Lindenlaan, Sint Odilienberg', [
     { street: 'Lindenlaan' }, { locality: 'Sint Odilienberg' }
-  ], true)
+  ])
 
   assert('Bosserdijk, Hoogland', [
     { street: 'Bosserdijk' }, { locality: 'Hoogland' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.nzd.test.js
+++ b/test/address.nzd.test.js
@@ -3,99 +3,99 @@ const testcase = (test, common) => {
 
   assert('21 Viaduct Harbour Avenue', [
     { housenumber: '21' }, { street: 'Viaduct Harbour Avenue' }
-  ], true)
+  ])
 
   assert('30 Town Point Road', [
     { housenumber: '30' }, { street: 'Town Point Road' }
-  ], true)
+  ])
 
   assert('2 Te Mako Mako Lane', [
     { housenumber: '2' }, { street: 'Te Mako Mako Lane' }
-  ], true)
+  ])
 
   assert('56 Blue Ridge Drive', [
     { housenumber: '56' }, { street: 'Blue Ridge Drive' }
-  ], true)
+  ])
 
   assert('14 Glen Neaves', [
     { housenumber: '14' }, { street: 'Glen Neaves' }
-  ], true)
+  ])
 
   assert('516 Old Taupo Road', [
     { housenumber: '516' }, { street: 'Old Taupo Road' }
-  ], true)
+  ])
 
   assert('5658 State Highway 27', [
     { housenumber: '5658' }, { street: 'State Highway 27' }
-  ], true)
+  ])
 
   assert('2 Meadows Lane', [
     { housenumber: '2' }, { street: 'Meadows Lane' }
-  ], true)
+  ])
 
   assert('19 Francis Drake Street', [
     { housenumber: '19' }, { street: 'Francis Drake Street' }
-  ], true)
+  ])
 
   assert('115-121 Hutt Park Road', [
     { housenumber: '115-121' }, { street: 'Hutt Park Road' }
-  ], true)
+  ])
 
   assert('62 Garden Road', [
     { housenumber: '62' }, { street: 'Garden Road' }
-  ], true)
+  ])
 
   assert('26 Pine Hill Rise', [
     { housenumber: '26' }, { street: 'Pine Hill Rise' }
-  ], true)
+  ])
 
   assert('23 Old Wharf Road', [
     { housenumber: '23' }, { street: 'Old Wharf Road' }
-  ], true)
+  ])
 
   assert('183 Vista Paku', [
     { housenumber: '183' }, { street: 'Vista Paku' }
-  ], true)
+  ])
 
   assert('109 Mathesons Corner Road', [
     { housenumber: '109' }, { street: 'Mathesons Corner Road' }
-  ], true)
+  ])
 
   assert('81 Park Terrace', [
     { housenumber: '81' }, { street: 'Park Terrace' }
-  ], true)
+  ])
 
   assert('320 Cannon Hill Crescent', [
     { housenumber: '320' }, { street: 'Cannon Hill Crescent' }
-  ], true)
+  ])
 
   assert('16 The Stables', [
     { housenumber: '16' }, { street: 'The Stables' }
-  ], true)
+  ])
 
   assert('35 Forbes Road', [
     { housenumber: '35' }, { street: 'Forbes Road' }
-  ], true)
+  ])
 
   assert('40 O\'Shannessey Street', [
     { housenumber: '40' }, { street: 'O\'Shannessey Street' }
-  ], true)
+  ])
 
   // assert('37 Hillpark Drive', [
   //   { housenumber: '37' }, { street: 'Hillpark Drive' }
-  // ], true)
+  // ])
 
   // assert('260 Broadway', [
   //   { housenumber: '260' }, { street: 'Broadway' }
-  // ], true)
+  // ])
 
   // assert('16 Tullamore', [
   //   { housenumber: '16' }, { street: 'Tullamore' }
-  // ], true)
+  // ])
 
   assert('4207 Mountain Road', [
     { housenumber: '4207' }, { street: 'Mountain Road' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.nzd.test.js
+++ b/test/address.nzd.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('21 Viaduct Harbour Avenue', [
     { housenumber: '21' }, { street: 'Viaduct Harbour Avenue' }

--- a/test/address.prt.test.js
+++ b/test/address.prt.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Rua Luis de Camoes', [
     { street: 'Rua Luis de Camoes' }

--- a/test/address.prt.test.js
+++ b/test/address.prt.test.js
@@ -3,31 +3,31 @@ const testcase = (test, common) => {
 
   assert('Rua Luis de Camoes', [
     { street: 'Rua Luis de Camoes' }
-  ], true)
+  ])
 
   assert('Rua Padre Cruz 31 3060-187 Cantanhede', [
     { street: 'Rua Padre Cruz' }, { housenumber: '31' },
     { postcode: '3060-187' }, { locality: 'Cantanhede' }
-  ], true)
+  ])
 
   assert('Tv. da Horta 27A', [
     { street: 'Tv. da Horta' }, { housenumber: '27A' }
-  ], true)
+  ])
 
   assert('R Academia das Ciências 17C 1200-030 Lisboa', [
     { street: 'R Academia das Ciências' }, { housenumber: '17C' },
     { postcode: '1200-030' }, { region: 'Lisboa' }
-  ], true)
+  ])
 
   assert('Rua do Sol a Santa Catarina 17B, 1200-452 Lisboa', [
     { street: 'Rua do Sol a Santa Catarina' }, { housenumber: '17B' },
     { postcode: '1200-452' }, { region: 'Lisboa' }
-  ], true)
+  ])
 
   assert('Tv. dos Fiéis de Deus 12C Lisboa Portugal', [
     { street: 'Tv. dos Fiéis de Deus' }, { housenumber: '12C' },
     { region: 'Lisboa' }, { country: 'Portugal' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -3,48 +3,48 @@ const testcase = (test, common) => {
 
   assert('Martin Luther King Jr. Blvd.', [
     { street: 'Martin Luther King Jr. Blvd.' }
-  ], true)
+  ])
 
   assert('Martin Luther King Blvd.', [
     { street: 'Martin Luther King Blvd.' }
-  ], true)
+  ])
 
   assert('1900 SE A ST, SAN FRANCISCO', [
     { housenumber: '1900' }, { street: 'SE A ST' },
     { locality: 'SAN FRANCISCO' }
-  ], true)
+  ])
 
   assert('1900 SE F ST, SAN FRANCISCO', [
     { housenumber: '1900' }, { street: 'SE F ST' },
     { locality: 'SAN FRANCISCO' }
-  ], true)
+  ])
 
   // postcode allowed in first position when only 1 token
-  assert('90210', [{ postcode: '90210' }], true)
+  assert('90210', [{ postcode: '90210' }])
 
   // postcode allowed in first position when only 1 token in section
-  assert('90210, CA', [{ postcode: '90210' }, { region: 'CA' }], true)
+  assert('90210, CA', [{ postcode: '90210' }, { region: 'CA' }])
 
   // postcode not allowed in first position otherwise
-  assert('90210 Foo', [])
+  assert('90210 Foo', [], false)
 
   // autocomplete street name jitter
   // note: we are only testing the street name stays the same throughout
-  assert('N FISKE AVE', [{ street: 'N FISKE AVE' }], true)
-  assert('N FISKE AVE P', [{ street: 'N FISKE AVE' }], true)
-  assert('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }], true)
-  assert('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }], true)
-  assert('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }], true)
-  assert('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }], true)
-  assert('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }], true)
-  assert('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }], true)
-  assert('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }], true)
-  assert('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }], true)
-  assert('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }], true)
-  assert('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }], true)
-  assert('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }], true)
-  assert('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }], true)
-  assert('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }], true)
+  assert('N FISKE AVE', [{ street: 'N FISKE AVE' }])
+  assert('N FISKE AVE P', [{ street: 'N FISKE AVE' }])
+  assert('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }])
+  assert('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }])
+  assert('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }])
+  assert('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }])
+  assert('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }])
+  assert('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }])
+  assert('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }])
+  assert('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assert('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }])
+  assert('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assert('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assert('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assert('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Martin Luther King Jr. Blvd.', [
     { street: 'Martin Luther King Jr. Blvd.' }

--- a/test/addressit.aus.test.js
+++ b/test/addressit.aus.test.js
@@ -1,11 +1,8 @@
-const AddressParser = require('../parser/AddressParser')
-
 // tests copied from 'npm addressit'
 // https://github.com/DamonOehlman/addressit/tree/master/test
 
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('2649 Logan Road, Eight Mile Plains, QLD 4113', [
     { housenumber: '2649' }, { street: 'Logan Road' },

--- a/test/addressit.aus.test.js
+++ b/test/addressit.aus.test.js
@@ -8,49 +8,49 @@ const testcase = (test, common) => {
     { housenumber: '2649' }, { street: 'Logan Road' },
     { locality: 'Eight Mile Plains' },
     { region: 'QLD' }, { postcode: '4113' }
-  ], true)
+  ])
 
   assert('2649 Logan Road Eight Mile Plains, QLD 4113', [
     { housenumber: '2649' }, { street: 'Logan Road' },
     { locality: 'Eight Mile Plains' },
     { region: 'QLD' }, { postcode: '4113' }
-  ], true)
+  ])
 
   assert('1 Queen Street, Brisbane 4000', [
     { housenumber: '1' }, { street: 'Queen Street' },
     { locality: 'Brisbane' }, { postcode: '4000' }
-  ], true)
+  ])
 
   assert('754 Robinson Rd West, Aspley, QLD 4035', [
     { housenumber: '754' }, { street: 'Robinson Rd West' },
     { locality: 'Aspley' }, { region: 'QLD' }, { postcode: '4035' }
-  ], true)
+  ])
 
   assert('Sydney 2000', [
     { locality: 'Sydney' }, { postcode: '2000' }
-  ], true)
+  ])
 
-  assert('Perth', [{ locality: 'Perth' }], true)
+  assert('Perth', [{ locality: 'Perth' }])
 
   assert('1/135 Ferny Way, Ferny Grove 4054', [
     { housenumber: '1/135' }, { street: 'Ferny Way' },
     { locality: 'Ferny Grove' }, { postcode: '4054' }
-  ], true)
+  ])
 
   assert('Eight Mile Plains 4113', [
     { locality: 'Eight Mile Plains' }, { postcode: '4113' }
-  ], true)
+  ])
 
   assert('8/437 St Kilda Road Melbourne, VIC ', [
     { housenumber: '8/437' }, { street: 'St Kilda Road' },
     { locality: 'Melbourne' }, { region: 'VIC' }
-  ], true)
+  ])
 
-  assert('BOOM', [{ locality: 'BOOM' }], true)
+  assert('BOOM', [{ locality: 'BOOM' }])
 
   assert('Eight Mile Plains 9999', [
     { locality: 'Eight Mile Plains' }, { postcode: '9999' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/addressit.usa.test.js
+++ b/test/addressit.usa.test.js
@@ -8,95 +8,95 @@ const testcase = (test, common) => {
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
-  ], true)
+  ])
 
   assert('123 Main St New York, NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
-  ], true)
+  ])
 
   assert('123 Main St New York NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
-  ], true)
+  ])
 
   assert('123 E 21st st, Brooklyn NY 11020', [
     { housenumber: '123' }, { street: 'E 21st st' },
     { locality: 'Brooklyn' }, { region: 'NY' },
     { postcode: '11020' }
-  ], true)
+  ])
 
   assert('754 Pharr Rd, Atlanta, Georgia 31035', [
     { housenumber: '754' }, { street: 'Pharr Rd' },
     { locality: 'Atlanta' }, { region: 'Georgia' },
     { postcode: '31035' }
-  ], true)
+  ])
 
   assert('601 21st Ave N, Myrtle Beach, South Carolina 29577', [
     { housenumber: '601' }, { street: '21st Ave N' },
     { locality: 'Myrtle Beach' }, { region: 'South Carolina' },
     { postcode: '29577' }
-  ], true)
+  ])
 
   assert('425 W 23rd St, New York, NY 10011', [
     { housenumber: '425' }, { street: 'W 23rd St' },
     { locality: 'New York' }, { region: 'NY' }, { postcode: '10011' }
-  ], true)
+  ])
 
   assert('1035 Comanchee Trl, West Columbia, South Carolina 29169', [
     { housenumber: '1035' }, { street: 'Comanchee Trl' },
     { locality: 'West Columbia' }, { region: 'South Carolina' },
     { postcode: '29169' }
-  ], true)
+  ])
 
-  assert('Texas 76013', [{ region: 'Texas' }, { postcode: '76013' }], true)
+  assert('Texas 76013', [{ region: 'Texas' }, { postcode: '76013' }])
 
-  assert('Dallas', [{ locality: 'Dallas' }], true)
+  assert('Dallas', [{ locality: 'Dallas' }])
 
-  assert('California', [{ region: 'California' }], true)
+  assert('California', [{ region: 'California' }])
 
-  assert('New York', [{ locality: 'New York' }], true)
+  assert('New York', [{ locality: 'New York' }])
 
-  assert('New York, NY', [{ locality: 'New York' }, { region: 'NY' }], true)
+  assert('New York, NY', [{ locality: 'New York' }, { region: 'NY' }])
 
   assert('New York, New York', [
     { locality: 'New York' }, { region: 'New York' }
-  ], true)
+  ])
 
-  // assert('northern mariana islands', [], true)
+  // assert('northern mariana islands', [])
 
   assert('Santa Monica, California 90407', [
     { locality: 'Santa Monica' }, { region: 'California' }, { postcode: '90407' }
-  ], true)
+  ])
 
   assert('Grand canyon 86023', [
     { locality: 'Grand canyon' }, { postcode: '86023' }
-  ], true)
+  ])
 
-  assert('CT, 06410', [{ region: 'CT' }, { postcode: '06410' }], true)
+  assert('CT, 06410', [{ region: 'CT' }, { postcode: '06410' }])
 
-  assert('BOOM', [{ locality: 'BOOM' }], true)
+  assert('BOOM', [{ locality: 'BOOM' }])
 
   assert('Niagara Falls 76B09', [
     { locality: 'Niagara Falls' }
-  ], true)
+  ])
 
   // assert('123 Broadway, New York, NY 10010', [
   //   { street: '123 Broadway' }, { locality: 'New York' }, { region: 'NY' }, { postcode: '10010' }
-  // ], true)
+  // ])
 
   assert('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', [
     { place: 'Mt Tabor Park' },
     { housenumber: '6220' }, { street: 'SE Salmon St' },
     { locality: 'Portland' }, { region: 'OR' },
     { postcode: '97215' }, { country: 'USA' }
-  ], true)
+  ])
 
-  // assert('Mt Tabor Park', [], true)
+  // assert('Mt Tabor Park', [])
 
-  assert('Mt', [{ region: 'Mt' }], true)
+  assert('Mt', [{ region: 'Mt' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/addressit.usa.test.js
+++ b/test/addressit.usa.test.js
@@ -1,11 +1,8 @@
-const AddressParser = require('../parser/AddressParser')
-
 // tests copied from 'npm addressit'
 // https://github.com/DamonOehlman/addressit/tree/master/test
 
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('123 Main St, New York, NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },

--- a/test/common.js
+++ b/test/common.js
@@ -19,7 +19,7 @@ const assert = (test, parser) => {
     p.solve(tokenizer)
     test(input, (t) => {
       let ext = extract(tokenizer)
-      t.deepEquals(firstOnly ? ext[0] : ext, expected)
+      t.deepEquals(firstOnly === false ? ext : ext[0], expected)
       t.end()
     })
   }

--- a/test/common.js
+++ b/test/common.js
@@ -1,4 +1,6 @@
 const Tokenizer = require('../tokenization/Tokenizer')
+const AddressParser = require('../parser/AddressParser')
+const globalParser = new AddressParser()
 
 const extract = (tokenizer) => {
   return tokenizer.solution.map(s => s.pair.map(c => {
@@ -9,15 +11,18 @@ const extract = (tokenizer) => {
   }))
 }
 
-const assert = (test, parser, input, expected, firstOnly) => {
-  let tokenizer = new Tokenizer(input)
-  parser.classify(tokenizer)
-  parser.solve(tokenizer)
-  test(input, (t) => {
-    let ext = extract(tokenizer)
-    t.deepEquals(firstOnly ? ext[0] : ext, expected)
-    t.end()
-  })
+const assert = (test, parser) => {
+  let p = (parser || globalParser)
+  return (input, expected, firstOnly) => {
+    let tokenizer = new Tokenizer(input)
+    p.classify(tokenizer)
+    p.solve(tokenizer)
+    test(input, (t) => {
+      let ext = extract(tokenizer)
+      t.deepEquals(firstOnly ? ext[0] : ext, expected)
+      t.end()
+    })
+  }
 }
 
 module.exports.assert = assert

--- a/test/compound_street.test.js
+++ b/test/compound_street.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   // street simple
   assert('Foostraße', [{ street: 'Foostraße' }], true)

--- a/test/compound_street.test.js
+++ b/test/compound_street.test.js
@@ -2,16 +2,16 @@ const testcase = (test, common) => {
   let assert = common.assert(test)
 
   // street simple
-  assert('Foostraße', [{ street: 'Foostraße' }], true)
+  assert('Foostraße', [{ street: 'Foostraße' }])
 
   // should not attach a second suffix
-  assert('Foostraße Rd', [{ street: 'Foostraße' }], true)
-  assert('foo st and', [{ street: 'foo st' }], true)
+  assert('Foostraße Rd', [{ street: 'Foostraße' }])
+  assert('foo st and', [{ street: 'foo st' }])
 
   // address simple
   assert('Foostraße 1', [
     { street: 'Foostraße' }, { housenumber: '1' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -2,86 +2,86 @@ const testcase = (test, common) => {
   let assert = common.assert(test)
 
   // street simple
-  assert('main pl', [{ street: 'main pl' }], true)
+  assert('main pl', [{ street: 'main pl' }])
 
   // street directional
-  assert('west main st', [{ street: 'west main st' }], true)
-  assert('main st west', [{ street: 'main st west' }], true)
+  assert('west main st', [{ street: 'west main st' }])
+  assert('main st west', [{ street: 'main st west' }])
 
   // street ordinal
-  assert('10th ave', [{ street: '10th ave' }], true)
+  assert('10th ave', [{ street: '10th ave' }])
 
   // street cardinal
-  assert('10 ave', [{ street: '10 ave' }], true)
+  assert('10 ave', [{ street: '10 ave' }])
 
   // address simple
   assert('1 main pl', [
     { housenumber: '1' }, { street: 'main pl' }
-  ], true)
+  ])
 
   // address with ordinal
   assert('100 10th ave', [
     { housenumber: '100' }, { street: '10th ave' }
-  ], true)
+  ])
 
   // address with cardinal
   assert('100 10 ave', [
     { housenumber: '100' }, { street: '10 ave' }
-  ], true)
+  ])
 
   // address with directional
   assert('1 north main blvd', [
     { housenumber: '1' }, { street: 'north main blvd' }
-  ], true)
+  ])
   assert('1 main blvd north', [
     { housenumber: '1' }, { street: 'main blvd north' }
-  ], true)
+  ])
 
   // address with directional & ordinal
   assert('30 west 26th street', [
     { housenumber: '30' }, { street: 'west 26th street' }
-  ], true)
+  ])
 
   // street with directional, ordinal & admin info
   assert('West 26th Street, New York, NYC, 10010', [
     { street: 'West 26th Street' },
     { locality: 'New York' },
     { postcode: '10010' }
-  ], true)
+  ])
 
   // do not classify tokens preceeded by a 'place' as
   // an admin classification
   assert('Portland Cafe Portland OR', [
     { place: 'Portland Cafe' },
     { locality: 'Portland' }, { region: 'OR' }
-  ], true)
+  ])
 
   // trailing directional causes issue with autocomplete
-  assert('1 Foo St N', [{ housenumber: '1' }, { street: 'Foo St' }], true)
-  assert('1 Foo St S', [{ housenumber: '1' }, { street: 'Foo St' }], true)
-  assert('1 Foo St E', [{ housenumber: '1' }, { street: 'Foo St' }], true)
-  assert('1 Foo St W', [{ housenumber: '1' }, { street: 'Foo St' }], true)
+  assert('1 Foo St N', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assert('1 Foo St S', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assert('1 Foo St E', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assert('1 Foo St W', [{ housenumber: '1' }, { street: 'Foo St' }])
 
   // ...but we allow two letter directionals
-  assert('1 Foo St NW', [{ housenumber: '1' }, { street: 'Foo St NW' }], true)
-  assert('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }], true)
-  assert('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }], true)
-  assert('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }], true)
+  assert('1 Foo St NW', [{ housenumber: '1' }, { street: 'Foo St NW' }])
+  assert('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }])
+  assert('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }])
+  assert('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }])
 
   // invalid solutions (because the classification pairings dont make sense logically)
-  assert('1 San Francisco', [])
-  assert('1 California', [])
-  assert('1 USA', [])
-  assert('1 San Francisco California', [])
-  assert('1 San Francisco USA', [])
-  assert('1 San Francisco California USA', [])
-  assert('1 California USA', [])
-  assert('1 90210', [])
+  assert('1 San Francisco', [], false)
+  assert('1 California', [], false)
+  assert('1 USA', [], false)
+  assert('1 San Francisco California', [], false)
+  assert('1 San Francisco USA', [], false)
+  assert('1 San Francisco California USA', [], false)
+  assert('1 California USA', [], false)
+  assert('1 90210', [], false)
 
   // do not parse 'aus' as a locality if it follows a region
   assert('new south wales aus', [
     { region: 'new south wales' }, { country: 'aus' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   // street simple
   assert('main pl', [{ street: 'main pl' }], true)

--- a/test/intersection.test.js
+++ b/test/intersection.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   // intersection queries
 

--- a/test/intersection.test.js
+++ b/test/intersection.test.js
@@ -6,125 +6,125 @@ const testcase = (test, common) => {
   // intersection tokens as a prefix are currently unsupported
   // assert('Corner of Main St & Second Ave', [
   //   { street: 'Main St' }, { street: 'Second Ave' }
-  // ], true)
+  // ])
   // assert('cnr west st and north ave', [
   //   { street: 'west st' }, { street: 'north ave' }
-  // ], true)
+  // ])
 
   assert('Main St & Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
-  ], true)
+  ])
 
   assert('Main St @ Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
-  ], true)
+  ])
 
   assert('Gleimstraße an der ecke von Schönhauser Allee', [
     { street: 'Gleimstraße' }, { street: 'Schönhauser Allee' }
-  ], true)
+  ])
 
   assert('Gleimstraße und Schönhauserallee', [
     { street: 'Gleimstraße' }, { street: 'Schönhauserallee' }
-  ], true)
+  ])
 
   // should not consider intersection tokens for street name
-  assert('& b', [])
-  assert('@ b', [])
-  assert('at b', [])
-  assert('a &', [])
-  assert('a @', [])
-  assert('a at', [])
-  assert('& street', [])
-  assert('@ street', [])
-  assert('carrer &', [])
-  assert('carrer @', [])
+  assert('& b', [], false)
+  assert('@ b', [], false)
+  assert('at b', [], false)
+  assert('a &', [], false)
+  assert('a @', [], false)
+  assert('a at', [], false)
+  assert('& street', [], false)
+  assert('@ street', [], false)
+  assert('carrer &', [], false)
+  assert('carrer @', [], false)
 
   // should correctly parse street names containing an intersection token
-  assert('at street', [{ street: 'at street' }], true)
-  assert('corner street', [{ street: 'corner street' }], true)
-  assert('carrer en', [{ street: 'carrer en' }], true)
-  assert('carrer con', [{ street: 'carrer con' }], true)
+  assert('at street', [{ street: 'at street' }])
+  assert('corner street', [{ street: 'corner street' }])
+  assert('carrer en', [{ street: 'carrer en' }])
+  assert('carrer con', [{ street: 'carrer con' }])
 
   // no street suffix
   assert('foo & bar', [
     { street: 'foo' }, { street: 'bar' }
-  ], true)
+  ])
   assert('foo and bar', [
     { street: 'foo' }, { street: 'bar' }
-  ], true)
+  ])
   assert('foo at bar', [
     { street: 'foo' }, { street: 'bar' }
-  ], true)
+  ])
   assert('foo @ bar', [
     { street: 'foo' }, { street: 'bar' }
-  ], true)
+  ])
 
   // missing street suffix - alpha
   assert('main st & side ave', [
     { street: 'main st' }, { street: 'side ave' }
-  ], true)
+  ])
   assert('main st & side', [
     { street: 'main st' }, { street: 'side' }
-  ], true)
+  ])
   assert('main & side ave', [
     { street: 'main' }, { street: 'side ave' }
-  ], true)
+  ])
   assert('main & side', [
     { street: 'main' }, { street: 'side' }
-  ], true)
+  ])
 
   // missing street suffix - ordinal
   assert('1st st & 2nd ave', [
     { street: '1st st' }, { street: '2nd ave' }
-  ], true)
+  ])
   assert('1st st & 2nd', [
     { street: '1st st' }, { street: '2nd' }
-  ], true)
+  ])
   assert('1st & 2nd ave', [
     { street: '1st' }, { street: '2nd ave' }
-  ], true)
+  ])
   assert('1st & 2nd', [
     { street: '1st' }, { street: '2nd' }
-  ], true)
+  ])
 
   // missing street suffix - cardinal
   assert('1 st & 2 ave', [
     { street: '1 st' }, { street: '2 ave' }
-  ], true)
+  ])
   assert('1 st & 2', [
     { street: '1 st' }, { street: '2' }
-  ], true)
+  ])
   assert('1 & 2 ave', [
     { street: '1' }, { street: '2 ave' }
-  ], true)
+  ])
   assert('1 & 2', [
     { street: '1' }, { street: '2' }
-  ], true)
+  ])
 
   assert('SW 6th & Pine', [
     { street: 'SW 6th' }, { street: 'Pine' }
-  ], true)
+  ])
 
   assert('9th and Lambert', [
     { street: '9th' }, { street: 'Lambert' }
-  ], true)
+  ])
 
   assert('filbert & 32nd', [
     { street: 'filbert' }, { street: '32nd' }
-  ], true)
+  ])
 
   // Should not detect this as an intersection
   // assert('University of Hawaii at Hilo', [
   //   { street: 'SW 6th' }, { street: 'Pine' }
-  // ], true)
+  // ])
   assert('national air and space museum', [
     { place: 'national air and space museum' }
-  ], true)
+  ])
 
   // Trimet syntax
   // assert('9,Lambert', [
   //   { street: '9' }, { street: 'Lambert' }
-  // ], true)
+  // ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/libpostal.test.js
+++ b/test/libpostal.test.js
@@ -9,7 +9,7 @@ const testcase = (test, common) => {
     { housenumber: '3360' }, { street: 'Grand Ave' },
     { locality: 'Oakland' }, { postcode: '94610-2737' },
     { region: 'CA' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/libpostal.test.js
+++ b/test/libpostal.test.js
@@ -1,11 +1,8 @@
-const AddressParser = require('../parser/AddressParser')
-
 // test cases from libpostal
 // https://github.com/openvenues/libpostal/issues
 
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   // https://github.com/openvenues/libpostal/issues/382
   assert('3360 Grand Ave Oakland 94610-2737 CA', [

--- a/test/transit.test.js
+++ b/test/transit.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Stop 1', [
     { place: 'Stop 1' }

--- a/test/transit.test.js
+++ b/test/transit.test.js
@@ -3,11 +3,11 @@ const testcase = (test, common) => {
 
   assert('Stop 1', [
     { place: 'Stop 1' }
-  ], true)
+  ])
 
   assert('Stop 10010', [
     { place: 'Stop 10010' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/venue.usa.test.js
+++ b/test/venue.usa.test.js
@@ -4,7 +4,7 @@ const testcase = (test, common) => {
   assert('Air & Space Museum Washington DC', [
     { place: 'Air & Space Museum' },
     { locality: 'Washington' }, { region: 'DC' }
-  ], true)
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/venue.usa.test.js
+++ b/test/venue.usa.test.js
@@ -1,8 +1,5 @@
-const AddressParser = require('../parser/AddressParser')
-
 const testcase = (test, common) => {
-  let parser = new AddressParser()
-  let assert = common.assert.bind(null, test, parser)
+  let assert = common.assert(test)
 
   assert('Air & Space Museum Washington DC', [
     { place: 'Air & Space Museum' },


### PR DESCRIPTION
These are some changes I've been meaning to make to the test runner:
- refactor tests to use a common instance of the 'AddressParser' (this halves the time it takes to run the tests 🎉)
- set `firstOnly=true` as the default for tests, so we don't have to always add `true` to the end of arrays, you may now optionally test all solutions by specifying `false`, but this simplifies the common case.

cc @Joxit 