### PR TITLE
speed up test execution

### DIFF
--- a/classifier/AlphaNumericClassifier.test.js
+++ b/classifier/AlphaNumericClassifier.test.js
@@ -4,13 +4,13 @@ const NumericClassification = require('../classification/NumericClassification')
 const AlphaNumericClassification = require('../classification/AlphaNumericClassification')
 const PunctuationClassification = require('../classification/PunctuationClassification')
 const Span = require('../tokenization/Span')
+const classifier = new AlphaNumericClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new AlphaNumericClassifier()
   let s = new Span(body)
-  c.each(s)
+  classifier.each(s)
   return s
 }
 

--- a/classifier/ChainClassifier.test.js
+++ b/classifier/ChainClassifier.test.js
@@ -1,13 +1,13 @@
 const ChainClassifier = require('./ChainClassifier')
 const ChainClassification = require('../classification/ChainClassification')
 const Span = require('../tokenization/Span')
+const classifier = new ChainClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new ChainClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 

--- a/classifier/CompositeClassifier.test.js
+++ b/classifier/CompositeClassifier.test.js
@@ -1,11 +1,10 @@
 const CompositeClassifier = require('./CompositeClassifier')
 const Span = require('../tokenization/Span')
+const classifier = new CompositeClassifier()
 
 module.exports.tests = {}
 
 module.exports.tests.match = (test) => {
-  let classifier = new CompositeClassifier([])
-
   test('match: scheme.is multi-token', (t) => {
     let scheme = { is: ['PositiveClassification'] }
 

--- a/classifier/CompoundStreetClassifier.test.js
+++ b/classifier/CompoundStreetClassifier.test.js
@@ -1,22 +1,21 @@
 const CompoundStreetClassifier = require('./CompoundStreetClassifier')
 const StreetClassification = require('../classification/StreetClassification')
 const Span = require('../tokenization/Span')
+const classifier = new CompoundStreetClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new CompoundStreetClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new CompoundStreetClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/DirectionalClassifier.test.js
+++ b/classifier/DirectionalClassifier.test.js
@@ -1,22 +1,21 @@
 const DirectionalClassifier = require('./DirectionalClassifier')
 const DirectionalClassification = require('../classification/DirectionalClassification')
 const Span = require('../tokenization/Span')
+const classifier = new DirectionalClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new DirectionalClassifier()
   let s = new Span(body)
-  c.each(s)
+  classifier.each(s)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new DirectionalClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s)
+    classifier.each(s)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/GivenNameClassifier.test.js
+++ b/classifier/GivenNameClassifier.test.js
@@ -1,22 +1,21 @@
 const GivenNameClassifier = require('./GivenNameClassifier')
 const GivenNameClassification = require('../classification/GivenNameClassification')
 const Span = require('../tokenization/Span')
+const classifier = new GivenNameClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new GivenNameClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new GivenNameClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/HouseNumberClassifier.test.js
+++ b/classifier/HouseNumberClassifier.test.js
@@ -1,22 +1,21 @@
 const HouseNumberClassifier = require('./HouseNumberClassifier')
 const HouseNumberClassification = require('../classification/HouseNumberClassification')
 const Span = require('../tokenization/Span')
+const classifier = new HouseNumberClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new HouseNumberClassifier()
   let s = new Span(body)
-  c.each(s)
+  classifier.each(s)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new HouseNumberClassifier()
     let s = new Span('100')
     s.contains.numerals = false
-    c.each(s)
+    classifier.each(s)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/OrdinalClassifier.test.js
+++ b/classifier/OrdinalClassifier.test.js
@@ -1,22 +1,21 @@
 const OrdinalClassifier = require('./OrdinalClassifier')
 const OrdinalClassification = require('../classification/OrdinalClassification')
 const Span = require('../tokenization/Span')
+const classifier = new OrdinalClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new OrdinalClassifier()
   let s = new Span(body)
-  c.each(s)
+  classifier.each(s)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new OrdinalClassifier()
     let s = new Span('100')
     s.contains.numerals = false
-    c.each(s)
+    classifier.each(s)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/PersonClassifier.test.js
+++ b/classifier/PersonClassifier.test.js
@@ -1,22 +1,21 @@
 const PersonClassifier = require('./PersonClassifier')
 const PersonClassification = require('../classification/PersonClassification')
 const Span = require('../tokenization/Span')
+const classifier = new PersonClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new PersonClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new PersonClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/PersonalSuffixClassifier.test.js
+++ b/classifier/PersonalSuffixClassifier.test.js
@@ -1,22 +1,21 @@
 const PersonalSuffixClassifier = require('./PersonalSuffixClassifier')
 const PersonalSuffixClassification = require('../classification/PersonalSuffixClassification')
 const Span = require('../tokenization/Span')
+const classifier = new PersonalSuffixClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new PersonalSuffixClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new PersonalSuffixClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/PersonalTitleClassifier.test.js
+++ b/classifier/PersonalTitleClassifier.test.js
@@ -1,22 +1,21 @@
 const PersonalTitleClassifier = require('./PersonalTitleClassifier')
 const PersonalTitleClassification = require('../classification/PersonalTitleClassification')
 const Span = require('../tokenization/Span')
+const classifier = new PersonalTitleClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new PersonalTitleClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new PersonalTitleClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/PlaceClassifier.test.js
+++ b/classifier/PlaceClassifier.test.js
@@ -1,22 +1,21 @@
 const PlaceClassifier = require('./PlaceClassifier')
 const PlaceClassification = require('../classification/PlaceClassification')
 const Span = require('../tokenization/Span')
+const classifier = new PlaceClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new PlaceClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new PlaceClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/PostcodeClassifier.test.js
+++ b/classifier/PostcodeClassifier.test.js
@@ -1,22 +1,21 @@
 const PostcodeClassifier = require('./PostcodeClassifier')
 const PostcodeClassification = require('../classification/PostcodeClassification')
 const Span = require('../tokenization/Span')
+const classifier = new PostcodeClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new PostcodeClassifier()
   let s = new Span(body)
-  c.each(s)
+  classifier.each(s)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new PostcodeClassifier()
     let s = new Span('100')
     s.contains.numerals = false
-    c.each(s)
+    classifier.each(s)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/StopWordClassifier.test.js
+++ b/classifier/StopWordClassifier.test.js
@@ -1,22 +1,21 @@
 const StopWordClassifier = require('./StopWordClassifier')
 const StopWordClassification = require('../classification/StopWordClassification')
 const Span = require('../tokenization/Span')
+const classifier = new StopWordClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new StopWordClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new StopWordClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/StreetPrefixClassifier.test.js
+++ b/classifier/StreetPrefixClassifier.test.js
@@ -1,22 +1,21 @@
 const StreetPrefixClassifier = require('./StreetPrefixClassifier')
 const StreetPrefixClassification = require('../classification/StreetPrefixClassification')
 const Span = require('../tokenization/Span')
+const classifier = new StreetPrefixClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new StreetPrefixClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new StreetPrefixClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })
@@ -24,8 +23,7 @@ module.exports.tests.contains_numerals = (test) => {
 
 module.exports.tests.single_character_tokens = (test) => {
   test('index: does contain single char tokens', (t) => {
-    let c = new StreetPrefixClassifier()
-    t.true(Object.keys(c.index).some(token => token.length < 2))
+    t.true(Object.keys(classifier.index).some(token => token.length < 2))
     t.end()
   })
 }

--- a/classifier/StreetSuffixClassifier.test.js
+++ b/classifier/StreetSuffixClassifier.test.js
@@ -1,22 +1,21 @@
 const StreetSuffixClassifier = require('./StreetSuffixClassifier')
 const StreetSuffixClassification = require('../classification/StreetSuffixClassification')
 const Span = require('../tokenization/Span')
+const classifier = new StreetSuffixClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new StreetSuffixClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new StreetSuffixClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })
@@ -24,8 +23,7 @@ module.exports.tests.contains_numerals = (test) => {
 
 module.exports.tests.single_character_tokens = (test) => {
   test('index: does not contain single char tokens', (t) => {
-    let c = new StreetSuffixClassifier()
-    t.false(Object.keys(c.index).some(token => token.length < 2))
+    t.false(Object.keys(classifier.index).some(token => token.length < 2))
     t.end()
   })
 }

--- a/classifier/SurnameClassifier.test.js
+++ b/classifier/SurnameClassifier.test.js
@@ -1,22 +1,21 @@
 const SurnameClassifier = require('./SurnameClassifier')
 const SurnameClassification = require('../classification/SurnameClassification')
 const Span = require('../tokenization/Span')
+const classifier = new SurnameClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new SurnameClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 
 module.exports.tests.contains_numerals = (test) => {
   test('contains numerals: honours contains.numerals boolean', (t) => {
-    let c = new SurnameClassifier()
     let s = new Span('example')
     s.contains.numerals = true
-    c.each(s, null, 1)
+    classifier.each(s, null, 1)
     t.deepEqual(s.classifications, {})
     t.end()
   })

--- a/classifier/TokenPositionClassifier.test.js
+++ b/classifier/TokenPositionClassifier.test.js
@@ -1,12 +1,12 @@
 const TokenPositionClassifier = require('./TokenPositionClassifier')
 const Tokenizer = require('../tokenization/Tokenizer')
+const classifier = new TokenPositionClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new TokenPositionClassifier()
   let t = new Tokenizer(body)
-  c.classify(t)
+  classifier.classify(t)
 
   // generate an array containing all the spans
   // with a final token classification

--- a/classifier/WhosOnFirstClassifier.test.js
+++ b/classifier/WhosOnFirstClassifier.test.js
@@ -1,12 +1,12 @@
 const WhosOnFirstClassifier = require('./WhosOnFirstClassifier')
 const Span = require('../tokenization/Span')
+const classifier = new WhosOnFirstClassifier()
 
 module.exports.tests = {}
 
 function classify (body) {
-  let c = new WhosOnFirstClassifier()
   let s = new Span(body)
-  c.each(s, null, 1)
+  classifier.each(s, null, 1)
   return s
 }
 

--- a/solver/Solution.test.js
+++ b/solver/Solution.test.js
@@ -1,5 +1,4 @@
 const Solution = require('./Solution')
-const AddressParser = require('../parser/AddressParser')
 const Tokenizer = require('../tokenization/Tokenizer')
 
 module.exports.tests = {}
@@ -25,13 +24,12 @@ module.exports.tests.constructor = (test) => {
 // @todo
 // module.exports.tests.computeScore = (test) => {}
 
-module.exports.tests.mask = (test) => {
-  let parser = new AddressParser()
+module.exports.tests.mask = (test, common) => {
   test('mask', (t) => {
     //                            'VVVVVV VVV  SSSSSSSSSSSS NN PPPPP AAAAAA'
     let tokenizer = new Tokenizer('Kaschk Bar, Linienstraße 40 10119 Berlin')
-    parser.classify(tokenizer)
-    parser.solve(tokenizer)
+    common.parser.classify(tokenizer)
+    common.parser.solve(tokenizer)
 
     t.equal(tokenizer.solution[0].mask(tokenizer), 'VVVVVVVVVV  SSSSSSSSSSSS NN PPPPP AAAAAA')
     t.end()
@@ -39,8 +37,8 @@ module.exports.tests.mask = (test) => {
   test('mask', (t) => {
     //                            'VVV VVVV NN SSSSSSS AAAAAA PPPPP      '
     let tokenizer = new Tokenizer('Foo Cafe 10 Main St London 10010 Earth')
-    parser.classify(tokenizer)
-    parser.solve(tokenizer)
+    common.parser.classify(tokenizer)
+    common.parser.solve(tokenizer)
 
     t.equal(tokenizer.solution[0].mask(tokenizer), 'VVVVVVVV NN SSSSSSS AAAAAA PPPPP      ')
     t.end()

--- a/test/common.js
+++ b/test/common.js
@@ -27,3 +27,4 @@ const assert = (test, parser) => {
 
 module.exports.assert = assert
 module.exports.extract = extract
+module.exports.parser = globalParser


### PR DESCRIPTION
following on from https://github.com/pelias/parser/pull/52

This PR refactors the classifier tests so that each classifier is only instantiated once per test.
The major advantage is that the `WhosOnFirst` classifier doesn't have to load all the dictionaries for each test.

This reduces the test runner execution time to 3s on my laptop (down from 20s+ at the start of the day) 🎉 