### PR TITLE
Supports for single quotes in personal title

### DIFF
--- a/classifier/PersonalTitleClassifier.test.js
+++ b/classifier/PersonalTitleClassifier.test.js
@@ -24,7 +24,7 @@ module.exports.tests.contains_numerals = (test) => {
 module.exports.tests.classify = (test) => {
   let valid = [
     'Général', 'General', 'gal',
-    'Saint', 'st', 'cdt'
+    'Saint', 'st', 'cdt', 'l\'Amiral'
   ]
 
   valid.forEach(token => {

--- a/resources/pelias/dictionaries/libpostal/fr/personal_titles.txt
+++ b/resources/pelias/dictionaries/libpostal/fr/personal_titles.txt
@@ -1,0 +1,4 @@
+l'amiral
+adjudant|l'adjudant
+empereur|l'empereur
+inspecteur|l'inspecteur

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -100,6 +100,22 @@ const testcase = (test, common) => {
   assert('École Jules Vernes Villetaneuse', [
     { place: 'École Jules Vernes' }, { locality: 'Villetaneuse' }
   ])
+
+  assert(`Rue de l'Amiral Galache, Toulouse`, [
+    { street: `Rue de l'Amiral Galache` }, { locality: 'Toulouse' }
+  ])
+
+  assert(`Rue de l'Inspecteur Alles Paris`, [
+    { street: `Rue de l'Inspecteur Alles` }, { locality: 'Paris' }
+  ])
+
+  assert(`Rue de l'Empereur Julien Paris`, [
+    { street: `Rue de l'Empereur Julien` }, { locality: 'Paris' }
+  ])
+
+  assert(`Rue de l'Adjudant Réau Paris`, [
+    { street: `Rue de l'Adjudant Réau` }, { locality: 'Paris' }
+  ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
## Background

In the French grammar, there are 8 article `le`, `la`, `les`, `un`, `une`, `du`, `de`, `la`. When an article like `le` or `de` is used with a noun which starts with a vowel, the article's vowel is replaced by a simple quote. For example, we don't write `Le Amiral` but `L'Amiral`.

## So what ?

This PR fixes these edge cases which are common.
I think this should be spread in some other classifiers (such as `GivenNameClassifier`)