### PR TITLE
Supports wildcard in wof files to import custom files for other languages

### DIFF
--- a/classifier/WhosOnFirstClassifier.js
+++ b/classifier/WhosOnFirstClassifier.js
@@ -13,11 +13,11 @@ const normalize = require('../tokenization/normalizer')({ lowercase: true, remov
 // note: these should be defined from most granular to least granular
 const placetypes = {
   'locality': {
-    files: ['name:eng_x_preferred.txt', 'name:fra_x_preferred.txt'],
+    files: ['name:*_x_preferred.txt'],
     classifications: [AreaClassification, LocalityClassification]
   },
   'region': {
-    files: ['abrv:eng_x_preferred.txt', 'name:eng_x_preferred.txt'],
+    files: ['abrv:*_x_preferred.txt', 'name:*_x_preferred.txt'],
     classifications: [AreaClassification, RegionClassification]
   },
   // 'dependency': {
@@ -25,7 +25,7 @@ const placetypes = {
   //   classifications: [AreaClassification, DependencyClassification]
   // },
   'country': {
-    files: ['name:eng_x_preferred.txt', 'wof:country.txt', 'wof:country_alpha3.txt'],
+    files: ['name:*_x_preferred.txt', 'wof:country.txt', 'wof:country_alpha3.txt'],
     classifications: [AreaClassification, CountryClassification]
   }
 }

--- a/resources/custom/custom.js
+++ b/resources/custom/custom.js
@@ -1,20 +1,5 @@
-const fs = require('fs')
 const path = require('path')
+const resourceLoader = require('../helper').resourceLoader
 const dictPath = path.join(__dirname, `./dictionaries`)
 
-function load (filename, add, remove) {
-  let filepath = path.join(dictPath, filename)
-  if (!fs.existsSync(filepath)) { return }
-  let dict = fs.readFileSync(filepath, 'utf8')
-  dict.split('\n').forEach(row => {
-    if (row.trim().startsWith('#')) {
-      // Do nothing, this is a comment
-    } else if (row.startsWith('!')) {
-      row.substring(1).split('|').forEach(remove)
-    } else {
-      row.split('|').forEach(add)
-    }
-  })
-}
-
-module.exports.load = load
+module.exports.load = resourceLoader(dictPath)

--- a/resources/helper.js
+++ b/resources/helper.js
@@ -1,0 +1,52 @@
+const fs = require('fs')
+const path = require('path')
+
+function generateFilenames (directory, filenames) {
+  return filenames.reduce((acc, filename) => {
+    if (filename.indexOf('*') < 0) {
+      acc.push(filename)
+      return acc
+    } else if (!fs.existsSync(directory)) {
+      return acc
+    }
+    // We use a UNIX synthax in our classifier, so we need to transform this in to a JS RegExp
+    const regex = new RegExp(filename.replace('*', '.*'))
+
+    return acc.concat(fs.readdirSync(directory).filter(f => regex.test(f)))
+  }, [])
+}
+
+function singleResourceLoader (filepath, add, remove) {
+  if (!fs.existsSync(filepath)) { return }
+  let dict = fs.readFileSync(filepath, 'utf8')
+  dict.split('\n').forEach(row => {
+    if (row.trim().startsWith('#')) {
+      // Do nothing, this is a comment
+    } else if (row.startsWith('!')) {
+      row.substring(1).split('|').forEach(remove)
+    } else {
+      row.split('|').forEach(add)
+    }
+  })
+}
+
+function multiResourceLoader ({ directory, filenames }, add, remove) {
+  generateFilenames(directory, filenames).forEach(filename => {
+    let filepath = path.join(directory, filename)
+    singleResourceLoader(filepath, add, remove)
+  })
+}
+
+function resourceLoader (dictPath) {
+  return (opts, add, remove) => {
+    if (typeof opts === 'string') {
+      let filename = path.join(dictPath, opts)
+      return singleResourceLoader(filename, add, remove)
+    }
+    let directory = path.join(dictPath, opts.directory)
+    multiResourceLoader({ directory: directory, filenames: opts.filenames }, add, remove)
+  }
+}
+
+module.exports.generateFilenames = generateFilenames
+module.exports.resourceLoader = resourceLoader

--- a/resources/pelias/pelias.js
+++ b/resources/pelias/pelias.js
@@ -1,20 +1,5 @@
-const fs = require('fs')
 const path = require('path')
+const resourceLoader = require('../helper').resourceLoader
 const dictPath = path.join(__dirname, `./dictionaries`)
 
-function load (filename, add, remove) {
-  let filepath = path.join(dictPath, filename)
-  if (!fs.existsSync(filepath)) { return }
-  let dict = fs.readFileSync(filepath, 'utf8')
-  dict.split('\n').forEach(row => {
-    if (row.trim().startsWith('#')) {
-      // Do nothing, this is a comment
-    } else if (row.startsWith('!')) {
-      row.substring(1).split('|').forEach(remove)
-    } else {
-      row.split('|').forEach(add)
-    }
-  })
-}
-
-module.exports.load = load
+module.exports.load = resourceLoader(dictPath)

--- a/resources/whosonfirst/whosonfirst.js
+++ b/resources/whosonfirst/whosonfirst.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const pelias = require('../pelias/pelias')
 const custom = require('../custom/custom')
+const generateFilenames = require('../helper').generateFilenames
 const dictPath = path.join(__dirname, `./dictionaries`)
 const allPlacetypes = fs.readdirSync(dictPath).filter(p => !p.includes('.'))
 
@@ -10,8 +11,9 @@ function load (set, placetypes, filenames, options) {
   const remove = _remove(set, options)
 
   placetypes.forEach(placetype => {
-    filenames.forEach(filename => {
-      let filepath = path.join(dictPath, placetype, filename)
+    const directory = path.join(dictPath, placetype)
+    generateFilenames(directory, filenames).forEach(filename => {
+      let filepath = path.join(directory, filename)
       if (!fs.existsSync(filepath)) { return }
       let dict = fs.readFileSync(filepath, 'utf8')
       dict.split('\n').forEach(row => {
@@ -21,15 +23,11 @@ function load (set, placetypes, filenames, options) {
   }, this)
 
   placetypes.forEach(placetype => {
-    filenames.forEach(filename => {
-      pelias.load(path.join('whosonfirst', placetype, filename), add, remove)
-    })
+    pelias.load({ directory: path.join('whosonfirst', placetype), filenames: filenames }, add, remove)
   })
 
   placetypes.forEach(placetype => {
-    filenames.forEach(filename => {
-      custom.load(path.join('whosonfirst', placetype, filename), add, remove)
-    })
+    custom.load({ directory: path.join('whosonfirst', placetype), filenames: filenames }, add, remove)
   })
 }
 


### PR DESCRIPTION
With the current WOF resources management, it's impossible to load other languages than French and English even though we have the option to add custom data.

That's why I changed a bit the WOF classifier to use wildcard in file names. With this feature, we can load all files with a pattern in a folder (such as `name:*_x_preferred.txt`, which will load `name:eng_x_preferred.txt`, `name:fra_x_preferred.txt`....).

Note: @missinglink since we now have the custom folder, you may need to move all your WOF dictionaries in the custom folder and update the `.gitignore`

Maybe I should add something to ignore custom configuration when we run tests ?