### PR TITLE
Supports for hyphen as alternative spans

### DIFF
--- a/classifier/CompositeClassifier.js
+++ b/classifier/CompositeClassifier.js
@@ -79,9 +79,9 @@ class CompositeClassifier extends SectionClassifier {
           let prev = c[i - 1]
 
           // enforce adjacency
-          if (next && curr.graph.findOne('child:last').graph.findOne('next') !== next.graph.findOne('child:first')) {
+          if (next && !curr.graph.findOne('child:last').graph.some('next', s => s === next.graph.findOne('child:first'))) {
             return false
-          } else if (prev && curr.graph.findOne('child:first').graph.findOne('prev') !== prev.graph.findOne('child:last')) {
+          } else if (prev && !curr.graph.findOne('child:first').graph.some('prev', s => s === prev.graph.findOne('child:last'))) {
             return false
           }
 

--- a/classifier/TokenPositionClassifier.js
+++ b/classifier/TokenPositionClassifier.js
@@ -19,19 +19,21 @@ class TokenPositionClassifier extends BaseClassifier {
     let firstSection = tokenizer.section[0]
     let firstSectionChildren = firstSection.graph.findAll('child')
     if (firstSectionChildren.length > 0) {
-      let firstChild = firstSectionChildren[0]
-      firstChild.classify(new StartTokenClassification(1.0))
+      firstSectionChildren.filter(s => !s.graph.findOne('prev')).forEach(firstChild => {
+        firstChild.classify(new StartTokenClassification(1.0))
+      })
     }
 
     // end token
     let lastSection = tokenizer.section[tokenizer.section.length - 1]
     let lastSectionChildren = lastSection.graph.findAll('child')
     if (lastSectionChildren.length > 0) {
-      let lastChild = lastSectionChildren[lastSectionChildren.length - 1]
-      lastChild.classify(new EndTokenClassification(1.0))
-      if (lastChild.norm.length === 1) {
-        lastChild.classify(new EndTokenSingleCharacterClassification(1.0))
-      }
+      lastSectionChildren.filter(s => !s.graph.findOne('next')).forEach(lastChild => {
+        lastChild.classify(new EndTokenClassification(1.0))
+        if (lastChild.norm.length === 1) {
+          lastChild.classify(new EndTokenSingleCharacterClassification(1.0))
+        }
+      })
     }
   }
 }

--- a/classifier/scheme/street.js
+++ b/classifier/scheme/street.js
@@ -199,7 +199,7 @@ module.exports = [
   },
   {
     // Rue Saint Anne
-    confidence: 0.81,
+    confidence: 0.91,
     Class: StreetClassification,
     scheme: [
       {

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -116,6 +116,10 @@ const testcase = (test, common) => {
   assert(`Rue de l'Adjudant Réau Paris`, [
     { street: `Rue de l'Adjudant Réau` }, { locality: 'Paris' }
   ])
+
+  assert(`10 Boulevard Saint-Germains Paris`, [
+    { housenumber: '10' }, { street: `Boulevard Saint-Germains` }, { locality: 'Paris' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/tokenization/Span.js
+++ b/tokenization/Span.js
@@ -71,3 +71,12 @@ class Span {
 }
 
 module.exports = Span
+module.exports.connectSiblings = (...spans) => {
+  // Supports both var-args and Array as argument
+  if (spans[0] instanceof Array) { spans = spans[0] }
+  spans.forEach((span, i) => {
+    if (spans[i - 1]) { span.graph.add('prev', spans[i - 1]) }
+    if (spans[i + 1]) { span.graph.add('next', spans[i + 1]) }
+  })
+  return spans
+}

--- a/tokenization/Span.test.js
+++ b/tokenization/Span.test.js
@@ -270,6 +270,33 @@ module.exports.tests.setPhrases = (test) => {
   })
 }
 
+module.exports.tests.connectSiblings = (test) => {
+  test('connectSiblings - array list', (t) => {
+    let spans = [new Span('A'), new Span('B'), new Span('C')]
+    Span.connectSiblings(spans)
+    t.deepEquals(spans[0].graph.findOne('next'), spans[1])
+    t.notOk(spans[0].graph.findOne('prev'))
+    t.deepEquals(spans[1].graph.findOne('next'), spans[2])
+    t.deepEquals(spans[1].graph.findOne('prev'), spans[0])
+    t.notOk(spans[2].graph.findOne('next'))
+    t.deepEquals(spans[2].graph.findOne('prev'), spans[1])
+    t.end()
+  })
+  test('connectSiblings - list of items', (t) => {
+    let a = new Span('A')
+    let b = new Span('B')
+    let c = new Span('C')
+    Span.connectSiblings(a, b, c)
+    t.deepEquals(a.graph.findOne('next'), b)
+    t.notOk(a.graph.findOne('prev'))
+    t.deepEquals(b.graph.findOne('next'), c)
+    t.deepEquals(b.graph.findOne('prev'), a)
+    t.notOk(c.graph.findOne('next'))
+    t.deepEquals(c.graph.findOne('prev'), b)
+    t.end()
+  })
+}
+
 module.exports.all = (tape, common) => {
   function test (name, testFunction) {
     return tape(`Span: ${name}`, testFunction)

--- a/tokenization/Tokenizer.js
+++ b/tokenization/Tokenizer.js
@@ -20,6 +20,7 @@ class Tokenizer {
   split () {
     for (let i = 0; i < this.section.length; i++) {
       this.section[i].setChildren(split(this.section[i], funcs.fieldsFuncWhiteSpace))
+      this.section[i].setChildren(split(this.section[i], funcs.fieldsFuncHyphenOrWhiteSpace))
     }
   }
 
@@ -31,12 +32,15 @@ class Tokenizer {
     }
   }
 
+  computeCoverageRec (sum, curr) {
+    if (!curr) { return sum }
+    return this.computeCoverageRec(sum + curr.end - curr.start, curr.graph.findOne('next'))
+  }
+
   computeCoverage () {
     this.coverage = 0
     this.section.forEach(s => {
-      this.coverage += s.graph.findAll('child').reduce(
-        (sum, cur) => sum + cur.end - cur.start, 0
-      )
+      this.coverage += this.computeCoverageRec(0, s.graph.findOne('child'))
     }, this)
   }
 }

--- a/tokenization/Tokenizer.test.js
+++ b/tokenization/Tokenizer.test.js
@@ -66,6 +66,22 @@ module.exports.tests.split = (test) => {
     t.equals(tok.section[3].graph.findAll('child')[0].body, 'USA')
     t.end()
   })
+  test('split: hyphen', (t) => {
+    let tok = new Tokenizer('20 Boulevard Saint-Germain, Paris, France')
+    t.true(tok.section.every(s => s.graph.findAll('child').every(c => c.constructor.name === 'Span')))
+    t.equals(tok.section.length, 3)
+    t.equals(tok.section[0].graph.findAll('child').length, 5)
+    t.equals(tok.section[0].graph.findAll('child')[0].body, '20')
+    t.equals(tok.section[0].graph.findAll('child')[1].body, 'Boulevard')
+    t.equals(tok.section[0].graph.findAll('child')[2].body, 'Saint-Germain')
+    t.equals(tok.section[0].graph.findAll('child')[3].body, 'Saint')
+    t.equals(tok.section[0].graph.findAll('child')[4].body, 'Germain')
+    t.equals(tok.section[1].graph.findAll('child').length, 1)
+    t.equals(tok.section[1].graph.findAll('child')[0].body, 'Paris')
+    t.equals(tok.section[2].graph.findAll('child').length, 1)
+    t.equals(tok.section[2].graph.findAll('child')[0].body, 'France')
+    t.end()
+  })
 }
 
 module.exports.tests.permute = (test) => {

--- a/tokenization/permutate.js
+++ b/tokenization/permutate.js
@@ -19,7 +19,7 @@ function permutateRec (prevSpan, s, windowCur, windowMin, windowMax, permutation
   // Create new span base on the previous and the next one
   let span = new Span(prevSpan.body + (prevSpan.body.length > 0 ? JOIN_CHAR : '') + s.body, prevSpan.start)
   // Add all children from the previous span to the new one, they will have the same ones + the next one
-  // Add to all childrend from the previous span the new span as parent + the next one
+  // Add to all children from the previous span the new span as parent + the next one
   prevSpan.graph.findAll('child').forEach(child => {
     span.graph.add('child', child)
     child.graph.add('parent', span)

--- a/tokenization/permutate.test.js
+++ b/tokenization/permutate.test.js
@@ -3,14 +3,21 @@ const permutate = require('./permutate')
 
 module.exports.tests = {}
 
+function generatePhrase (...spans) {
+  return spans.map((s, i) => {
+    if (i < spans.length - 1) { s.graph.add('next', spans[i + 1]) }
+    return s
+  })
+}
+
 module.exports.tests.permutate = (test) => {
   test('permutate: simple', (t) => {
-    let spans = [
+    let spans = generatePhrase(
       new Span('SoHo', 0),
       new Span('New', 5),
       new Span('York', 9),
       new Span('USA', 14)
-    ]
+    )
 
     // expected permutations
     let perm1 = new Span('SoHo New York USA', 0)
@@ -72,11 +79,11 @@ module.exports.tests.permutate = (test) => {
   })
 
   test('permutate: tokens contain whitespace', (t) => {
-    let spans = [
+    let spans = generatePhrase(
       new Span('SoHo', 0),
       new Span('New York', 5),
       new Span('USA', 14)
-    ]
+    )
 
     // expected permutations
     let perm1 = new Span('SoHo New York USA', 0)
@@ -117,12 +124,12 @@ module.exports.tests.permutate = (test) => {
   })
 
   test('permutate: smaller window', (t) => {
-    let spans = [
+    let spans = generatePhrase(
       new Span('SoHo', 0),
       new Span('New', 5),
       new Span('York', 9),
       new Span('USA', 13)
-    ]
+    )
 
     // expected permutations
     let perm1 = new Span('SoHo New', 0)
@@ -175,7 +182,7 @@ module.exports.tests.permutate = (test) => {
     span2.end = 14
     let span3 = new Span('York', 15)
     span3.end = 19
-    let spans = [span1, span2, span3]
+    let spans = generatePhrase(span1, span2, span3)
 
     // expected permutations
     let perm1 = new Span('SoHo New York', 2)
@@ -231,7 +238,7 @@ module.exports.tests.permutate = (test) => {
     let span1 = new Span('SoHo', 0)
     let span2 = new Span('New', 5)
     let span3 = new Span('York', 14)
-    let spans = [span1, span2, span3]
+    let spans = generatePhrase(span1, span2, span3)
 
     let actual = permutate(spans, 1, 6)
 

--- a/tokenization/permutate.test.js
+++ b/tokenization/permutate.test.js
@@ -10,6 +10,10 @@ function generatePhrase (...spans) {
   })
 }
 
+function getSpans (spans, ...indexes) {
+  return indexes.map(i => spans[i])
+}
+
 module.exports.tests.permutate = (test) => {
   test('permutate: simple', (t) => {
     let spans = generatePhrase(
@@ -280,6 +284,102 @@ module.exports.tests.permutate = (test) => {
     t.true(perm6.graph.findAll('child').includes(span3))
     t.true(span3.graph.findAll('parent').includes(perm6))
 
+    t.end()
+  })
+
+  test('permutate: with hyphen', (t) => {
+    let spans = generatePhrase(
+      new Span('SoHo', 0),
+      new Span('New-York', 5),
+      new Span('USA', 14)
+    )
+    spans.push(new Span('New', 5))
+    spans.push(new Span('York', 9))
+
+    // SoHo -> New
+    spans[0].graph.add('next', spans[3])
+    // New -> York
+    spans[3].graph.add('next', spans[4])
+    // York -> USA
+    spans[4].graph.add('next', spans[2])
+
+    // expected permutations
+    let perm1 = new Span('SoHo New-York USA', 0)
+    spans.slice(0, 3).forEach(s => perm1.graph.add('child', s))
+    perm1.graph.add('child:first', spans[0])
+    perm1.graph.add('child:last', spans[2])
+
+    let perm2 = new Span('SoHo New-York', 0)
+    spans.slice(0, 2).forEach(s => perm2.graph.add('child', s))
+    perm2.graph.add('child:first', spans[0])
+    perm2.graph.add('child:last', spans[1])
+
+    let perm3 = new Span('SoHo New York USA', 0)
+    getSpans(spans, 0, 3, 4, 2).forEach(s => perm3.graph.add('child', s))
+    perm3.graph.add('child:first', spans[0])
+    perm3.graph.add('child:last', spans[2])
+
+    let perm4 = new Span('SoHo New York', 0)
+    getSpans(spans, 0, 3, 4).forEach(s => perm4.graph.add('child', s))
+    perm4.graph.add('child:first', spans[0])
+    perm4.graph.add('child:last', spans[4])
+
+    let perm5 = new Span('SoHo New', 0)
+    getSpans(spans, 0, 3).forEach(s => perm5.graph.add('child', s))
+    perm5.graph.add('child:first', spans[0])
+    perm5.graph.add('child:last', spans[3])
+
+    let perm6 = new Span('SoHo', 0)
+    spans.slice(0, 1).forEach(s => perm6.graph.add('child', s))
+    perm6.graph.add('child:first', spans[0])
+    perm6.graph.add('child:last', spans[0])
+
+    let perm7 = new Span('New-York USA', 5)
+    spans.slice(1, 3).forEach(s => perm7.graph.add('child', s))
+    perm7.graph.add('child:first', spans[1])
+    perm7.graph.add('child:last', spans[2])
+
+    let perm8 = new Span('New-York', 5)
+    spans.slice(1, 2).forEach(s => perm8.graph.add('child', s))
+    perm8.graph.add('child:first', spans[1])
+    perm8.graph.add('child:last', spans[1])
+
+    let perm9 = new Span('USA', 14)
+    spans.slice(2, 3).forEach(s => perm9.graph.add('child', s))
+    perm9.graph.add('child:first', spans[2])
+    perm9.graph.add('child:last', spans[2])
+
+    let perm10 = new Span('New York USA', 5)
+    getSpans(spans, 3, 4, 2).forEach(s => perm10.graph.add('child', s))
+    perm10.graph.add('child:first', spans[3])
+    perm10.graph.add('child:last', spans[2])
+
+    let perm11 = new Span('New York', 5)
+    getSpans(spans, 3, 4).forEach(s => perm11.graph.add('child', s))
+    perm11.graph.add('child:first', spans[3])
+    perm11.graph.add('child:last', spans[4])
+
+    let perm12 = new Span('New', 5)
+    spans.slice(3, 4).forEach(s => perm12.graph.add('child', s))
+    perm12.graph.add('child:first', spans[3])
+    perm12.graph.add('child:last', spans[3])
+
+    let perm13 = new Span('York USA', 9)
+    getSpans(spans, 4, 2).forEach(s => perm13.graph.add('child', s))
+    perm13.graph.add('child:first', spans[4])
+    perm13.graph.add('child:last', spans[2])
+
+    let perm14 = new Span('York', 9)
+    spans.slice(4, 5).forEach(s => perm14.graph.add('child', s))
+    perm14.graph.add('child:first', spans[4])
+    perm14.graph.add('child:last', spans[4])
+
+    let actual = permutate(spans, 1, 10)
+    t.deepEquals(actual, [
+      perm1, perm2, perm3, perm4, perm5,
+      perm6, perm7, perm8, perm9, perm10,
+      perm11, perm12, perm13, perm14
+    ])
     t.end()
   })
 }

--- a/tokenization/permutate.test.js
+++ b/tokenization/permutate.test.js
@@ -3,20 +3,13 @@ const permutate = require('./permutate')
 
 module.exports.tests = {}
 
-function generatePhrase (...spans) {
-  return spans.map((s, i) => {
-    if (i < spans.length - 1) { s.graph.add('next', spans[i + 1]) }
-    return s
-  })
-}
-
 function getSpans (spans, ...indexes) {
   return indexes.map(i => spans[i])
 }
 
 module.exports.tests.permutate = (test) => {
   test('permutate: simple', (t) => {
-    let spans = generatePhrase(
+    let spans = Span.connectSiblings(
       new Span('SoHo', 0),
       new Span('New', 5),
       new Span('York', 9),
@@ -83,7 +76,7 @@ module.exports.tests.permutate = (test) => {
   })
 
   test('permutate: tokens contain whitespace', (t) => {
-    let spans = generatePhrase(
+    let spans = Span.connectSiblings(
       new Span('SoHo', 0),
       new Span('New York', 5),
       new Span('USA', 14)
@@ -128,7 +121,7 @@ module.exports.tests.permutate = (test) => {
   })
 
   test('permutate: smaller window', (t) => {
-    let spans = generatePhrase(
+    let spans = Span.connectSiblings(
       new Span('SoHo', 0),
       new Span('New', 5),
       new Span('York', 9),
@@ -186,7 +179,7 @@ module.exports.tests.permutate = (test) => {
     span2.end = 14
     let span3 = new Span('York', 15)
     span3.end = 19
-    let spans = generatePhrase(span1, span2, span3)
+    let spans = Span.connectSiblings(span1, span2, span3)
 
     // expected permutations
     let perm1 = new Span('SoHo New York', 2)
@@ -242,7 +235,7 @@ module.exports.tests.permutate = (test) => {
     let span1 = new Span('SoHo', 0)
     let span2 = new Span('New', 5)
     let span3 = new Span('York', 14)
-    let spans = generatePhrase(span1, span2, span3)
+    let spans = Span.connectSiblings(span1, span2, span3)
 
     let actual = permutate(spans, 1, 6)
 
@@ -288,7 +281,7 @@ module.exports.tests.permutate = (test) => {
   })
 
   test('permutate: with hyphen', (t) => {
-    let spans = generatePhrase(
+    let spans = Span.connectSiblings(
       new Span('SoHo', 0),
       new Span('New-York', 5),
       new Span('USA', 14)

--- a/tokenization/split.js
+++ b/tokenization/split.js
@@ -35,10 +35,7 @@ function split (span, f) {
   }
 
   // Add siblings to graph
-  spans.forEach((span, i) => {
-    if (spans[i - 1]) { span.graph.add('prev', spans[i - 1]) }
-    if (spans[i + 1]) { span.graph.add('next', spans[i + 1]) }
-  })
+  Span.connectSiblings(spans)
 
   return spans
 }

--- a/tokenization/split.js
+++ b/tokenization/split.js
@@ -14,7 +14,7 @@ function split (span, f) {
     let char = span.body.charAt(i)
     if (f(char)) {
       if (wasField) {
-        spans.push(new Span(
+        spans.push(span.graph.findAll('child').find(s => s.start === span.start + fromIndex && s.body === span.body.substring(fromIndex, i)) || new Span(
           span.body.substring(fromIndex, i),
           span.start + fromIndex
         ))
@@ -28,7 +28,7 @@ function split (span, f) {
 
   // Last field might end at EOF.
   if (wasField) {
-    spans.push(new Span(
+    spans.push(span.graph.findAll('child').find(s => s.start === span.start + fromIndex && s.body === span.body.substring(fromIndex, span.body.length)) || new Span(
       span.body.substring(fromIndex, span.body.length),
       span.start + fromIndex
     ))

--- a/tokenization/split_funcs.js
+++ b/tokenization/split_funcs.js
@@ -31,5 +31,10 @@ function fieldsFuncWhiteSpace (char) {
   return whitespace.test(char)
 }
 
+function fieldsFuncHyphenOrWhiteSpace (char) {
+  return char === '-' || fieldsFuncWhiteSpace(char)
+}
+
 module.exports.fieldsFuncBoundary = fieldsFuncBoundary
 module.exports.fieldsFuncWhiteSpace = fieldsFuncWhiteSpace
+module.exports.fieldsFuncHyphenOrWhiteSpace = fieldsFuncHyphenOrWhiteSpace


### PR DESCRIPTION
## Background

Sometime, parsing fails when words are not well split. Hyphens' main purpose is to glue words together. That meas, when an hyphen is used, we can process it like a simple space in order to have two separate words.

Only processing hyphens like spaces can unfortunately not be the final solution because the hyphen is also useful in some other cases.

That's why I suggest to take advantage of our graphs and add some alternative ways to complete a phrase without hyphens.

## How it works ?

When we split all sections, we do a first compute on spaces only (like before) and then a second compute on hyphen.

Example for `10 Boulevard Saint-Germain Paris`, when we split this section, we get this: `10`, `Boulevard`, `Saint-Germain`, `Paris`, here is the graph:

![step1](https://user-images.githubusercontent.com/5153882/63770799-3472b500-c8d6-11e9-8ffd-953af4b0f59e.png)

With the hyphen step, we will have `10`, `Boulevard`, `Saint-Germain`, `Paris`, `Saint`, `Germain`

![step2](https://user-images.githubusercontent.com/5153882/63770925-83204f00-c8d6-11e9-94c6-357f8aa48b06.png)

Thanks to this, we will be able to parse phrases such as :
- `10 Boulevard Saint-Germain Paris`: which is `housenumber` + `street` (first solution without this PR  :-1:)
- `10 Boulevard Saint-Germains Paris`: which is `housenumber` + `street` + `locality` (first solution with this PR :+1:)