### PR TITLE
Remove Germany from localities

### DIFF
--- a/resources/pelias/dictionaries/whosonfirst/locality/name:eng_x_preferred.txt
+++ b/resources/pelias/dictionaries/whosonfirst/locality/name:eng_x_preferred.txt
@@ -12,6 +12,7 @@ sf
 !airport
 !deli
 !us
+!germany
 # remove any localities which share a name with a US state
 !alabama
 !alaska


### PR DESCRIPTION
This fixes the classification of Germany as a locality.

Here are all localities from WOF named Germany:

- [1344073249](https://spelunker.whosonfirst.org/id/1344073249)
- [1343296991](https://spelunker.whosonfirst.org/id/1343296991)
- [1293498807](https://spelunker.whosonfirst.org/id/1293498807)
- [1343665787](https://spelunker.whosonfirst.org/id/1343665787)
- [1277080253](https://spelunker.whosonfirst.org/id/1277080253)


Fixes #63