### PR TITLE
feat(server): Redirect root path to demo

### DIFF
--- a/server/http.js
+++ b/server/http.js
@@ -45,6 +45,7 @@ app.use((req, res, next) => {
 // routes
 app.get('/parser/parse', require('./routes/parse'))
 app.use('/demo', express.static(path.join(__dirname, '/demo')))
+app.use('/', (req, res) => { res.redirect('/demo') })
 
 // start multi-threaded server
 if (cpus > 1) {


### PR DESCRIPTION
This adds a URL handler for the root path (`/`), so that by default it redirects to the demo. This is the same as the Placeholder demo, and just makes it a bit more user friendly.