### PR TITLE
change default query in demo

### DIFF
--- a/server/demo/index.html
+++ b/server/demo/index.html
@@ -192,7 +192,7 @@
       }
 
       // default text
-      return 'Gleimstraße zwischen Scönhauserallee 10117 Berlin';
+      return '1389a County Road 42 IA';
     }
 
     $(document).ready(function () {


### PR DESCRIPTION
change default query used in demo as DEU intersection parsing is currently disabled.
we're planning on releasing a blog post about `pelias/parser` shortly so I wanted to make the demo first-impression better.
