### PR TITLE
add -kanal as seperable street suffix

### DIFF
--- a/resources/pelias/dictionaries/libpostal/de/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/de/concatenated_suffixes_separable.txt
@@ -1,2 +1,3 @@
 str
 park
+kanal

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -27,6 +27,15 @@ const testcase = (test, common) => {
     { locality: 'Munich' }, { country: 'Germany' }
   ])
 
+  assert('Königsallee Düsseldorf', [
+    { street: 'Königsallee' },
+    { locality: 'Düsseldorf' }
+  ])
+
+  assert('Rathausplatz', [{ street: 'Rathausplatz' }])
+  assert('Plutoweg', [{ street: 'Plutoweg' }])
+  assert('Dorfstrasse', [{ street: 'Dorfstrasse' }])
+
   // autocomplete-style query includes partial postcode
   assert('Eberswalder Straße 100 104', [
     { street: 'Eberswalder Straße' }, { housenumber: '100' }

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -6,6 +6,11 @@ const testcase = (test, common) => {
     { postcode: '10437' }, { locality: 'Berlin' }
   ])
 
+  assert('Am Nordkanal 11, 47877 Willich', [
+    { street: 'Am Nordkanal' }, { housenumber: '11' },
+    { postcode: '47877' }, { locality: 'Willich' }
+  ])
+
   assert('Am Bürgerpark 15-18, 13156, Berlin', [
     { street: 'Am Bürgerpark' }, { housenumber: '15-18' },
     { postcode: '13156' }, { locality: 'Berlin' }


### PR DESCRIPTION
highlighted in https://github.com/pelias/pelias/issues/854 the parser was not familiar with `Am Nordkanal` being a valid street name.
I've added `-kanal` to the list of German suffixes commonly found in street names.

closes https://github.com/pelias/pelias/issues/854