### PR TITLE
Add support for unit type numbered

### DIFF
--- a/classification/UnitClassification.js
+++ b/classification/UnitClassification.js
@@ -1,0 +1,11 @@
+const Classification = require('./Classification')
+
+class UnitClassification extends Classification {
+  constructor (confidence, meta) {
+    super(confidence, meta)
+    this.public = true
+    this.label = 'unit'
+  }
+}
+
+module.exports = UnitClassification

--- a/classification/UnitClassification.test.js
+++ b/classification/UnitClassification.test.js
@@ -1,0 +1,24 @@
+const Classification = require('./UnitClassification')
+
+module.exports.tests = {}
+
+module.exports.tests.constructor = (test) => {
+  test('constructor', (t) => {
+    let c = new Classification()
+    t.true(c.public)
+    t.equals(c.label, 'unit')
+    t.equals(c.confidence, 1.0)
+    t.deepEqual(c.meta, {})
+    t.end()
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`UnitClassification: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classification/UnitTypeClassification.js
+++ b/classification/UnitTypeClassification.js
@@ -1,0 +1,11 @@
+const Classification = require('./Classification')
+
+class UnitTypeClassification extends Classification {
+  constructor (confidence, meta) {
+    super(confidence, meta)
+    this.public = true
+    this.label = 'unit_type'
+  }
+}
+
+module.exports = UnitTypeClassification

--- a/classification/UnitTypeClassification.test.js
+++ b/classification/UnitTypeClassification.test.js
@@ -1,0 +1,24 @@
+const Classification = require('./UnitTypeClassification')
+
+module.exports.tests = {}
+
+module.exports.tests.constructor = (test) => {
+  test('constructor', (t) => {
+    let c = new Classification()
+    t.true(c.public)
+    t.equals(c.label, 'unit_type')
+    t.equals(c.confidence, 1.0)
+    t.deepEqual(c.meta, {})
+    t.end()
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`UnitTypeClassification: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/CentralEuropeanStreetNameClassifier.js
+++ b/classifier/CentralEuropeanStreetNameClassifier.js
@@ -11,17 +11,16 @@ const StreetClassification = require('../classification/StreetClassification')
 
 class CentralEuropeanStreetNameClassifier extends SectionClassifier {
   each (section) {
-    // there must be excactly two childen in this section
-    // note: we may wish to relax/expand on this later
-    if (section.graph.length('child') !== 2) { return }
+    // there must at least two childen in this section
+    if (section.graph.length('child') < 2) { return }
 
     // get first and last child
     let children = section.graph.findAll('child')
     let first = _.first(children)
-    let last = _.last(children)
+    let next = first.graph.findOne('next')
 
     // section must end with a HouseNumberClassification
-    if (!last.classifications.hasOwnProperty('HouseNumberClassification')) { return }
+    if (!next || next.end !== section.end || !next.classifications.hasOwnProperty('HouseNumberClassification')) { return }
 
     // other elements cannot contain any public classifications
     if (_.some(first.classifications, (c) => c.public)) { return }

--- a/classifier/CentralEuropeanStreetNameClassifier.test.js
+++ b/classifier/CentralEuropeanStreetNameClassifier.test.js
@@ -7,15 +7,26 @@ const classifier = new CentralEuropeanStreetNameClassifier()
 
 module.exports.tests = {}
 module.exports.tests.classify = (test) => {
+  let foo = new Span('Foo')
+  let fooHouseNum = new Span('1', 4).classify(new HouseNumberClassification(1.0))
+  foo.graph.add('next', fooHouseNum)
+
+  let bar = new Span('Bar')
+  let barHouseNum = new Span('2137', 4).classify(new HouseNumberClassification(1.0))
+  bar.graph.add('next', barHouseNum)
+
+  let baz = new Span('Baz')
+  let bazHouseNum0 = new Span('152/160', 4).classify(new HouseNumberClassification(1.0))
+  let bazHouseNum1 = new Span('152', 4).classify(new HouseNumberClassification(1.0))
+  let bazHouseNum2 = new Span('160', 8).classify(new HouseNumberClassification(1.0))
+  baz.graph.add('next', bazHouseNum0)
+  baz.graph.add('next', bazHouseNum1)
+  bazHouseNum1.graph.add('next', bazHouseNum2)
+
   let valid = [
-    new Span('Foo 1').setChildren([
-      new Span('Foo'),
-      new Span('1').classify(new HouseNumberClassification(1.0))
-    ]),
-    new Span('Bar 2137').setChildren([
-      new Span('Bar'),
-      new Span('2137').classify(new HouseNumberClassification(1.0))
-    ])
+    new Span('Foo 1').setChildren([foo, fooHouseNum]),
+    new Span('Bar 2137').setChildren([bar, barHouseNum]),
+    new Span('Baz 152/160').setChildren([baz, bazHouseNum0, bazHouseNum1, bazHouseNum2])
   ]
 
   valid.forEach(s => {
@@ -32,8 +43,10 @@ module.exports.tests.classify = (test) => {
       })
 
       // last child was unchanged
-      t.deepEqual(_.last(children).classifications, {
-        HouseNumberClassification: new HouseNumberClassification(1)
+      _.tail(children).forEach(c => {
+        t.deepEqual(c.classifications, {
+          HouseNumberClassification: new HouseNumberClassification(1)
+        })
       })
 
       t.end()

--- a/classifier/HouseNumberClassifier.js
+++ b/classifier/HouseNumberClassifier.js
@@ -18,6 +18,12 @@ class HouseNumberClassifier extends WordClassifier {
         // /^\d{1,5}(к\d{1,5})?(с\d{1,5})?$/.test(span.body) // Russian style including korpus (cyrillic к) and stroenie (cyrillic с)
     ) {
       let confidence = 1
+      let prev = span.graph.findOne('prev')
+
+      // Housenumber must not be preceded by unit type
+      if (prev && prev.classifications.hasOwnProperty('UnitTypeClassification')) {
+        return
+      }
 
       // it's possible to have 5 digit housenumbers
       // but they are fairly uncommon

--- a/classifier/UnitClassifier.js
+++ b/classifier/UnitClassifier.js
@@ -1,0 +1,22 @@
+const WordClassifier = require('./super/WordClassifier')
+const UnitClassification = require('../classification/UnitClassification')
+
+class UnitClassifier extends WordClassifier {
+  each (span) {
+    // skip spans which do not contain numbers
+    if (!span.contains.numerals) { return }
+
+    if (/^\d+$/.test(span.body)) {
+      let prev = span.graph.findOne('prev')
+
+      // Unit must be preceded by unit type
+      if (!prev || !prev.classifications.hasOwnProperty('UnitTypeClassification')) {
+        return
+      }
+
+      span.classify(new UnitClassification(1))
+    }
+  }
+}
+
+module.exports = UnitClassifier

--- a/classifier/UnitClassifier.test.js
+++ b/classifier/UnitClassifier.test.js
@@ -1,0 +1,64 @@
+const UnitClassifier = require('./UnitClassifier')
+const UnitClassification = require('../classification/UnitClassification')
+const UnitTypeClassification = require('../classification/UnitTypeClassification')
+const Span = require('../tokenization/Span')
+const classifier = new UnitClassifier()
+
+module.exports.tests = {}
+
+function classify (body, prev) {
+  let s = new Span(body)
+  if (prev) {
+    let p = new Span(prev)
+    p.classify(new UnitTypeClassification(1.0))
+    s.graph.add('prev', p)
+  }
+  classifier.each(s)
+  return s
+}
+
+module.exports.tests.without_unit_type = (test) => {
+  test('number without unit type', (t) => {
+    let s = classify('2020')
+    t.deepEqual(s.classifications, { })
+    t.end()
+  })
+  test('letter without unit type', (t) => {
+    let s = classify('alpha')
+    t.deepEqual(s.classifications, { })
+    t.end()
+  })
+  test('number and letter without unit type', (t) => {
+    let s = classify('2020a')
+    t.deepEqual(s.classifications, { })
+    t.end()
+  })
+}
+
+module.exports.tests.with_unit_type = (test) => {
+  test('number with unit type', (t) => {
+    let s = classify('2020', 'unit')
+    t.deepEqual(s.classifications, { UnitClassification: new UnitClassification(1.0) })
+    t.end()
+  })
+  test('letters with unit type', (t) => {
+    let s = classify('alpha', 'unit')
+    t.deepEqual(s.classifications, { })
+    t.end()
+  })
+  test('number and letter with unit type', (t) => {
+    let s = classify('2020a', 'unit')
+    t.deepEqual(s.classifications, { })
+    t.end()
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`UnitClassification: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/UnitTypeClassifier.js
+++ b/classifier/UnitTypeClassifier.js
@@ -1,0 +1,22 @@
+const WordClassifier = require('./super/WordClassifier')
+const UnitTypeClassification = require('../classification/UnitTypeClassification')
+const libpostal = require('../resources/libpostal/libpostal')
+
+class UnitTypeClassifier extends WordClassifier {
+  setup () {
+    // load index tokens
+    this.index = {}
+    libpostal.load(this.index, ['en'], 'unit_types_numbered.txt')
+  }
+  each (span) {
+    // skip spans which contain numbers
+    if (span.contains.numerals) { return }
+
+    // use an inverted index for full token matching as it's O(1)
+    if (this.index.hasOwnProperty(span.norm)) {
+      span.classify(new UnitTypeClassification(1.0))
+    }
+  }
+}
+
+module.exports = UnitTypeClassifier

--- a/classifier/UnitTypeClassifier.test.js
+++ b/classifier/UnitTypeClassifier.test.js
@@ -1,0 +1,39 @@
+const UnitTypeClassifier = require('./UnitTypeClassifier')
+const UnitTypeClassification = require('../classification/UnitTypeClassification')
+const Span = require('../tokenization/Span')
+const classifier = new UnitTypeClassifier()
+
+module.exports.tests = {}
+
+function classify (body) {
+  let s = new Span(body)
+  classifier.each(s, null, 1)
+  return s
+}
+
+module.exports.tests.english_unit_types = (test) => {
+  let valid = [
+    'unit', 'apt', 'lot'
+  ]
+
+  valid.forEach(token => {
+    test(`english unit types: ${token}`, (t) => {
+      let s = classify(token)
+
+      t.deepEqual(s.classifications, {
+        UnitTypeClassification: new UnitTypeClassification(1, { })
+      })
+      t.end()
+    })
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`UnitTypeClassifier: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/UnitTypeUnitClassifier.js
+++ b/classifier/UnitTypeUnitClassifier.js
@@ -1,0 +1,54 @@
+const BaseClassifier = require('./super/BaseClassifier')
+const UnitTypeClassification = require('../classification/UnitTypeClassification')
+const UnitClassification = require('../classification/UnitClassification')
+const libpostal = require('../resources/libpostal/libpostal')
+const Span = require('../tokenization/Span')
+
+class UnitTypeClassifier extends BaseClassifier {
+  setup () {
+    // load index tokens
+    this.index = {}
+    libpostal.load(this.index, ['en'], 'unit_types_numbered.txt')
+  }
+  classify (tokenizer) {
+    for (let i = 0; i < tokenizer.section.length; i++) {
+      let children = tokenizer.section[i].graph.findAll('child')
+      for (let j = 0; j < children.length; j++) {
+        this.each(children[j], tokenizer.section[i])
+      }
+    }
+  }
+  each (span, section) {
+    // skip spans whithout numbers
+    if (!span.contains.numerals) { return }
+
+    // We a searching spans like `U12` which means `Unit 12`
+    for (let token in this.index) {
+      if (span.body.length < token.length) { continue }
+
+      // perf: https://gist.github.com/dai-shi/4950506
+      if (span.norm.substring(0, token.length) === token && /^\d+$/.test(span.norm.substring(token.length))) {
+        const unitTypeBody = span.body.substring(0, token.length)
+        const unitBody = span.body.substring(token.length)
+
+        const unitType = new Span(unitTypeBody, span.start)
+        const unit = new Span(unitBody, span.start + unitTypeBody.length)
+
+        // We are creating two spans `{unit_type} {unit}`
+        unitType.classify(new UnitTypeClassification(1.0))
+        unitType.graph.add('next', unit)
+        unit.classify(new UnitClassification(1.0))
+        unit.graph.add('prev', unitType)
+
+        span.graph.findAll('prev').forEach(prev => unitType.graph.add('prev', prev))
+        span.graph.findAll('next').forEach(next => unit.graph.add('next', next))
+
+        section.graph.add('child', unitType)
+        section.graph.add('child', unit)
+        return
+      }
+    }
+  }
+}
+
+module.exports = UnitTypeClassifier

--- a/classifier/UnitTypeUnitClassifier.test.js
+++ b/classifier/UnitTypeUnitClassifier.test.js
@@ -1,0 +1,58 @@
+const UnitTypeClassification = require('../classification/UnitTypeClassification')
+const UnitClassification = require('../classification/UnitClassification')
+const UnitTypeUnitClassifier = require('./UnitTypeUnitClassifier')
+const Span = require('../tokenization/Span')
+const classifier = new UnitTypeUnitClassifier()
+
+module.exports.tests = {}
+
+function classify (body) {
+  let s = new Span(body)
+  classifier.each(s, s)
+  return s
+}
+
+module.exports.tests.english_unit_types = (test) => {
+  let valid = [
+    'unit16', 'apt23', 'lot75'
+  ]
+
+  let invalid = [
+    'unit', '23', 'Main'
+  ]
+
+  valid.forEach(token => {
+    test(`english unit types: ${token}`, (t) => {
+      let s = classify(token)
+      let classifications = s.graph.findAll('child').map(s => s.classifications).filter(c => c)
+
+      t.equal(s.graph.findAll('child').length, 2)
+      t.deepEqual(classifications.find(c => c.UnitTypeClassification), {
+        UnitTypeClassification: new UnitTypeClassification(1, { })
+      })
+      t.deepEqual(classifications.find(c => c.UnitClassification), {
+        UnitClassification: new UnitClassification(1, { })
+      })
+      t.end()
+    })
+  })
+
+  invalid.forEach(token => {
+    test(`english unit types: ${token}`, (t) => {
+      let s = classify(token)
+
+      t.equal(s.graph.findAll('child').length, 0)
+      t.end()
+    })
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`UnitTypeUnitClassifier: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -2,6 +2,9 @@ const Parser = require('./Parser')
 const AlphaNumericClassifier = require('../classifier/AlphaNumericClassifier')
 const TokenPositionClassifier = require('../classifier/TokenPositionClassifier')
 const HouseNumberClassifier = require('../classifier/HouseNumberClassifier')
+const UnitClassifier = require('../classifier/UnitClassifier')
+const UnitTypeClassifier = require('../classifier/UnitTypeClassifier')
+const UnitTypeUnitClassifier = require('../classifier/UnitTypeUnitClassifier')
 const PostcodeClassifier = require('../classifier/PostcodeClassifier')
 const StreetPrefixClassifier = require('../classifier/StreetPrefixClassifier')
 const StreetSuffixClassifier = require('../classifier/StreetSuffixClassifier')
@@ -41,10 +44,13 @@ class AddressParser extends Parser {
       [
         // generic word classifiers
         new AlphaNumericClassifier(),
+        new UnitTypeUnitClassifier(),
         new TokenPositionClassifier(),
 
         // word classifiers
+        new UnitTypeClassifier(),
         new HouseNumberClassifier(),
+        new UnitClassifier(),
         new PostcodeClassifier(),
         new StreetPrefixClassifier(),
         new StreetSuffixClassifier(),

--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -120,6 +120,7 @@ class AddressParser extends Parser {
         new MustNotPreceedFilter('CountryClassification', 'PostcodeClassification'),
         new MustNotPreceedFilter('CountryClassification', 'StreetClassification'),
         new MustNotPreceedFilter('CountryClassification', 'HouseNumberClassification'),
+        new MustNotPreceedFilter('PlaceClassification', 'UnitClassification'),
         new MustNotFollowFilter('LocalityClassification', 'RegionClassification'),
         new MustNotFollowFilter('LocalityClassification', 'CountryClassification'),
         new HouseNumberPositionPenalty(),

--- a/resources/pelias/dictionaries/libpostal/en/unit_types_numbered.txt
+++ b/resources/pelias/dictionaries/libpostal/en/unit_types_numbered.txt
@@ -1,0 +1,3 @@
+!shop|shp
+!stop
+!store|stor

--- a/solver/Solution.js
+++ b/solver/Solution.js
@@ -57,7 +57,7 @@ class Solution {
 
   // return a mask of the input for this solution
   // which shows the areas covered by different types of classification
-  // N = housenumber, S = street, P = postcode, A = administrative
+  // N = housenumber, S = street, P = postcode, A = administrative, U = unit
   mask (tokenizer) {
     // use the original input, mask should be the same length
     let body = tokenizer.span.body
@@ -67,6 +67,8 @@ class Solution {
       'housenumber': 'N',
       'street': 'S',
       'postcode': 'P',
+      'unit': 'U',
+      'unit_type': 'U',
       'default': 'A'
     }
 

--- a/solver/Solution.test.js
+++ b/solver/Solution.test.js
@@ -43,6 +43,15 @@ module.exports.tests.mask = (test, common) => {
     t.equal(tokenizer.solution[0].mask(tokenizer), 'VVVVVVVV NN SSSSSSS AAAAAA PPPPP      ')
     t.end()
   })
+  test('mask', (t) => {
+    //                            'UUU UU NNN SSSSSSSSSSSSSS AAAAAAAAAAAA AAA PPPP'
+    let tokenizer = new Tokenizer('Lot 12/345 Illawarra Road Marrickville NSW 2204')
+    common.parser.classify(tokenizer)
+    common.parser.solve(tokenizer)
+
+    t.equal(tokenizer.solution[0].mask(tokenizer), 'UUU UU NNN SSSSSSSSSSSSSS AAAAAAAAAAAA AAA PPPP')
+    t.end()
+  })
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -5,6 +5,42 @@ const testcase = (test, common) => {
     { postcode: '6000' },
     { region: 'NSW' }, { country: 'Australia' }
   ])
+
+  assert('Unit 12/345 Main St', [
+    { unit_type: 'Unit' }, { unit: '12' },
+    { housenumber: '345' },
+    { street: 'Main St' }
+  ])
+
+  assert('U 12 345 Main St', [
+    { unit_type: 'U' }, { unit: '12' },
+    { housenumber: '345' },
+    { street: 'Main St' }
+  ])
+
+  assert('Apartment 12/345 Main St', [
+    { unit_type: 'Apartment' }, { unit: '12' },
+    { housenumber: '345' },
+    { street: 'Main St' }
+  ])
+
+  assert('Apt 12/345 Main St', [
+    { unit_type: 'Apt' }, { unit: '12' },
+    { housenumber: '345' },
+    { street: 'Main St' }
+  ])
+
+  assert('Lot 12/345 Main St', [
+    { unit_type: 'Lot' }, { unit: '12' },
+    { housenumber: '345' },
+    { street: 'Main St' }
+  ])
+
+  assert('U12/345 Main St', [
+    { unit_type: 'U' }, { unit: '12' },
+    { housenumber: '345' },
+    { street: 'Main St' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -41,6 +41,12 @@ const testcase = (test, common) => {
     { housenumber: '345' },
     { street: 'Main St' }
   ])
+
+  assert('Lot 12/345 Illawarra Road Marrickville NSW 2204', [
+    { unit_type: 'Lot' }, { unit: '12' }, { housenumber: '345' },
+    { street: 'Illawarra Road' }, { locality: 'Marrickville' },
+    { region: 'NSW' }, { postcode: '2204' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -47,6 +47,12 @@ const testcase = (test, common) => {
     { street: 'Illawarra Road' }, { locality: 'Marrickville' },
     { region: 'NSW' }, { postcode: '2204' }
   ])
+
+  assert('Lot 2, Burrows Avenue, EDMONDSON PARK, NSW, Australia', [
+    { unit_type: 'Lot' }, { unit: '2' },
+    { street: 'Burrows Avenue' }, { locality: 'EDMONDSON PARK' },
+    { region: 'NSW' }, { country: 'Australia' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/tokenization/split_funcs.js
+++ b/tokenization/split_funcs.js
@@ -32,7 +32,7 @@ function fieldsFuncWhiteSpace (char) {
 }
 
 function fieldsFuncHyphenOrWhiteSpace (char) {
-  return char === '-' || fieldsFuncWhiteSpace(char)
+  return char === '-' || char === '/' || fieldsFuncWhiteSpace(char)
 }
 
 module.exports.fieldsFuncBoundary = fieldsFuncBoundary


### PR DESCRIPTION
Hi there !

I added some support for `unit` :tada: 

**Classifications**
- `UnitTypeClassification`: public classifications for types like `unit`, `apt`...
- `UnitClassification`: public classification for unit numbers

**Classifiers**
- `UnitTypeClassifier`: classify a UnityType thanks to libpostal `unit_types_numbered.txt` (I removed `stop` and `shop`)
- `UnitClassifier`: classify a Unit, this must be after a unit type
- `UnitTypeUnitClassifier`: complex classifier for units like `U12`. This will parse a span and will add two new spans `U` and `12` in the section with the proper classification.


This fixes #71 and need more work for #69