### PR TITLE
chore: update better-sqlite3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "remove-accents": "^0.4.2"
   },
   "devDependencies": {
-    "better-sqlite3": "^5.4.0",
+    "better-sqlite3": "^6.0.1",
     "chalk": "^2.4.2",
     "csv-parse": "^4.4.1",
     "deep-eql": "^4.0.0",


### PR DESCRIPTION
the `better-sqlite3` dev dependency is only used in `resources/whosonfirst/generate.js`.
this PR updates it to use version 6+ which ships with prebuilt images, making `npm install` faster :rocket:

related https://github.com/pelias/parser/issues/90