### PR TITLE
add some *failing* test cases for Czech Republic

### DIFF
--- a/test/address.cze.test.js
+++ b/test/address.cze.test.js
@@ -15,6 +15,81 @@ const testcase = (test, common) => {
     { street: 'Beethovenova' }, { housenumber: '641/9' },
     { locality: 'Brno' }
   ])
+
+  // assert('Ostrava, U Koupaliště 1570/10', [
+  //   { street: 'U Koupaliště' }, { housenumber: '1570/10' },
+  //   { locality: 'Ostrava' }
+  // ])
+
+  // assert('Hradec Králové, Karla Čapka 694/5', [
+  //   { street: 'Karla Čapka' }, { housenumber: '694/5' },
+  //   { locality: 'Hradec Králové' }
+  // ])
+
+  // assert('Kolín, Pražská 3', [
+  //   { street: 'Pražská' }, { housenumber: '3' },
+  //   { locality: 'Kolín' }
+  // ])
+
+  // assert('Neratovice, Jungmannova 676', [
+  //   { street: 'Jungmannova' }, { housenumber: '676' },
+  //   { locality: 'Neratovice' }
+  // ])
+
+  // assert('Králíky, Bedřicha Smetany 561', [
+  //   { street: 'Bedřicha Smetany' }, { housenumber: '561' },
+  //   { locality: 'Králíky' }
+  // ])
+
+  // assert('Prachatice, Dlouhá 93', [
+  //   { street: 'Dlouhá' }, { housenumber: '93' },
+  //   { locality: 'Prachatice' }
+  // ])
+
+  // assert('Ronov nad Doubravou, Nábřežní 180', [
+  //   { street: 'Nábřežní' }, { housenumber: '180' },
+  //   { locality: 'Ronov nad Doubravou' }
+  // ])
+
+  // assert('Brno, Orlí 517/22', [
+  //   { street: 'Orlí' }, { housenumber: '517/22' },
+  //   { locality: 'Brno' }
+  // ])
+
+  // assert('Nový Jičín, Dvořákova 713/11', [
+  //   { street: 'Dvořákova' }, { housenumber: '713/11' },
+  //   { locality: 'Nový Jičín' }
+  // ])
+
+  // assert('Praha, V Šáreckém údolí 53/27', [
+  //   { street: 'V Šáreckém údolí' }, { housenumber: '53/27' },
+  //   { locality: 'Praha' }
+  // ])
+
+  // assert('Praha, Nad Panenskou 164/4', [
+  //   { street: 'Nad Panenskou' }, { housenumber: '164/4' },
+  //   { locality: 'Praha' }
+  // ])
+
+  // assert('Rožmitál pod Třemšínem, Kpt. Jaroše 403', [
+  //   { street: 'Kpt. Jaroše' }, { housenumber: '403' },
+  //   { locality: 'Rožmitál pod Třemšínem' }
+  // ])
+
+  // assert('Klatovy, Jiráskova 15', [
+  //   { street: 'Jiráskova' }, { housenumber: '15' },
+  //   { locality: 'Klatovy' }
+  // ])
+
+  // assert('Frýdek-Místek, Radniční 1244', [
+  //   { street: 'Radniční' }, { housenumber: '1244' },
+  //   { locality: 'Frýdek-Místek' }
+  // ])
+
+  // assert('Zlín, Rašínova 70', [
+  //   { street: 'Rašínova' }, { housenumber: '70' },
+  //   { locality: 'Zlín' }
+  // ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
add some *failing* testcases for Czech Republic provided in [this comment](https://github.com/pelias/parser/issues/83#issuecomment-617613386).

one of the reasons the tests are failing is due to come classification/solver code which disallows the locality name from preceding the address, so this might be a challenge to fix while maintaining the passing tests in the USA which rely on this.

I'm adding these tests anyway (albeit commented out) so we have them when we return to this issue in the future.

Example of the functionality which is preventing admin areas from preceding addresses:

```diff
diff --git a/parser/AddressParser.js b/parser/AddressParser.js
index 28776a6..835a791 100644
--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -79,7 +79,7 @@ class AddressParser extends Parser {
       // solvers
       [
         new ExclusiveCartesianSolver(),
-        new LeadingAreaDeclassifier(),
+        // new LeadingAreaDeclassifier(),
         new MultiStreetSolver(),
         new SubsetFilter(),
         new InvalidSolutionFilter([
@@ -105,8 +105,8 @@ class AddressParser extends Parser {
         new MustNotFollowFilter('PlaceClassification', 'PostcodeClassification'),
         new MustNotPreceedFilter('PostcodeClassification', 'HouseNumberClassification'),
         new MustNotPreceedFilter('PostcodeClassification', 'StreetClassification'),
-        new MustNotPreceedFilter('LocalityClassification', 'HouseNumberClassification'),
-        new MustNotPreceedFilter('LocalityClassification', 'StreetClassification'),
+        // new MustNotPreceedFilter('LocalityClassification', 'HouseNumberClassification'),
+        // new MustNotPreceedFilter('LocalityClassification', 'StreetClassification'),
         new MustNotPreceedFilter('RegionClassification', 'HouseNumberClassification'),
         new MustNotPreceedFilter('RegionClassification', 'StreetClassification'),
         new MustNotPreceedFilter('CountryClassification', 'RegionClassification'),
```