### PR TITLE
add field to place names

### DIFF
--- a/resources/libpostal/dictionaries/en/place_names.txt
+++ b/resources/libpostal/dictionaries/en/place_names.txt
@@ -108,7 +108,6 @@ family practice
 farmer's market|farmers market
 farm|frm
 farmhouse
-field
 fire department|fd|f d
 fire station
 fitness center|fitness centre

--- a/resources/libpostal/dictionaries/en/place_names.txt
+++ b/resources/libpostal/dictionaries/en/place_names.txt
@@ -108,6 +108,7 @@ family practice
 farmer's market|farmers market
 farm|frm
 farmhouse
+field
 fire department|fd|f d
 fire station
 fitness center|fitness centre

--- a/resources/pelias/dictionaries/libpostal/en/place_names.txt
+++ b/resources/pelias/dictionaries/libpostal/en/place_names.txt
@@ -3,3 +3,4 @@ cathedral
 stop
 !dist
 building
+field

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -1,6 +1,10 @@
 const testcase = (test, common) => {
   let assert = common.assert(test)
 
+  assert('wrigley field',
+    [ [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ], [ { locality: 'field' } ] ],
+    false)
+
   assert('Martin Luther King Jr. Blvd.', [
     { street: 'Martin Luther King Jr. Blvd.' }
   ])


### PR DESCRIPTION
"field" is common in large baseball stadiums like wrigley field and citi
field

this will be paired with another PR for api that notices if the top two
interpretations are full street & place parses, and if so, boosts
neither

this change alone fixes wrigley field in acceptance tests, that is the only change noticed there.


(base) ➜  acceptance-tests git:(master) ✗ diff dev-no-field.txt dev.txt
1255c1255
<   ✘ [4] "/v1/search?focus.point.lon=-87.6716&focus.point.lat=41.8218&text=wrigley field": score 1 out of 4
---
>   ✘ [4] "/v1/search?focus.point.lon=-87.6716&focus.point.lat=41.8218&text=wrigley field": score 4 out of 5
1257,1265c1257
<     layer
<       expected: venue
<       actual:   street
<     name
<       expected: Wrigley Field
<       actual:   Wrigley Field Drive
<     locality
<       expected: Chicago
<       actual:   Bethalto
---
>     priorityThresh is 1 but found at position 2
1771c1763
< Took 107116ms
---