### PR TITLE
rename "assert" function to be more readable

### DIFF
--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -1,54 +1,54 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('6000, NSW, Australia', [
+  assertFirstSolution('6000, NSW, Australia', [
     { postcode: '6000' },
     { region: 'NSW' }, { country: 'Australia' }
   ])
 
-  assertFirstMatch('Unit 12/345 Main St', [
+  assertFirstSolution('Unit 12/345 Main St', [
     { unit_type: 'Unit' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstMatch('U 12 345 Main St', [
+  assertFirstSolution('U 12 345 Main St', [
     { unit_type: 'U' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstMatch('Apartment 12/345 Main St', [
+  assertFirstSolution('Apartment 12/345 Main St', [
     { unit_type: 'Apartment' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstMatch('Apt 12/345 Main St', [
+  assertFirstSolution('Apt 12/345 Main St', [
     { unit_type: 'Apt' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstMatch('Lot 12/345 Main St', [
+  assertFirstSolution('Lot 12/345 Main St', [
     { unit_type: 'Lot' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstMatch('U12/345 Main St', [
+  assertFirstSolution('U12/345 Main St', [
     { unit_type: 'U' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstMatch('Lot 12/345 Illawarra Road Marrickville NSW 2204', [
+  assertFirstSolution('Lot 12/345 Illawarra Road Marrickville NSW 2204', [
     { unit_type: 'Lot' }, { unit: '12' }, { housenumber: '345' },
     { street: 'Illawarra Road' }, { locality: 'Marrickville' },
     { region: 'NSW' }, { postcode: '2204' }
   ])
 
-  assertFirstMatch('Lot 2, Burrows Avenue, EDMONDSON PARK, NSW, Australia', [
+  assertFirstSolution('Lot 2, Burrows Avenue, EDMONDSON PARK, NSW, Australia', [
     { unit_type: 'Lot' }, { unit: '2' },
     { street: 'Burrows Avenue' }, { locality: 'EDMONDSON PARK' },
     { region: 'NSW' }, { country: 'Australia' }

--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -1,54 +1,54 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('6000, NSW, Australia', [
+  assertFirstMatch('6000, NSW, Australia', [
     { postcode: '6000' },
     { region: 'NSW' }, { country: 'Australia' }
   ])
 
-  assertFirstParseMatches('Unit 12/345 Main St', [
+  assertFirstMatch('Unit 12/345 Main St', [
     { unit_type: 'Unit' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstParseMatches('U 12 345 Main St', [
+  assertFirstMatch('U 12 345 Main St', [
     { unit_type: 'U' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstParseMatches('Apartment 12/345 Main St', [
+  assertFirstMatch('Apartment 12/345 Main St', [
     { unit_type: 'Apartment' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstParseMatches('Apt 12/345 Main St', [
+  assertFirstMatch('Apt 12/345 Main St', [
     { unit_type: 'Apt' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstParseMatches('Lot 12/345 Main St', [
+  assertFirstMatch('Lot 12/345 Main St', [
     { unit_type: 'Lot' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstParseMatches('U12/345 Main St', [
+  assertFirstMatch('U12/345 Main St', [
     { unit_type: 'U' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assertFirstParseMatches('Lot 12/345 Illawarra Road Marrickville NSW 2204', [
+  assertFirstMatch('Lot 12/345 Illawarra Road Marrickville NSW 2204', [
     { unit_type: 'Lot' }, { unit: '12' }, { housenumber: '345' },
     { street: 'Illawarra Road' }, { locality: 'Marrickville' },
     { region: 'NSW' }, { postcode: '2204' }
   ])
 
-  assertFirstParseMatches('Lot 2, Burrows Avenue, EDMONDSON PARK, NSW, Australia', [
+  assertFirstMatch('Lot 2, Burrows Avenue, EDMONDSON PARK, NSW, Australia', [
     { unit_type: 'Lot' }, { unit: '2' },
     { street: 'Burrows Avenue' }, { locality: 'EDMONDSON PARK' },
     { region: 'NSW' }, { country: 'Australia' }

--- a/test/address.aus.test.js
+++ b/test/address.aus.test.js
@@ -1,54 +1,54 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('6000, NSW, Australia', [
+  assertFirstParseMatches('6000, NSW, Australia', [
     { postcode: '6000' },
     { region: 'NSW' }, { country: 'Australia' }
   ])
 
-  assert('Unit 12/345 Main St', [
+  assertFirstParseMatches('Unit 12/345 Main St', [
     { unit_type: 'Unit' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assert('U 12 345 Main St', [
+  assertFirstParseMatches('U 12 345 Main St', [
     { unit_type: 'U' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assert('Apartment 12/345 Main St', [
+  assertFirstParseMatches('Apartment 12/345 Main St', [
     { unit_type: 'Apartment' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assert('Apt 12/345 Main St', [
+  assertFirstParseMatches('Apt 12/345 Main St', [
     { unit_type: 'Apt' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assert('Lot 12/345 Main St', [
+  assertFirstParseMatches('Lot 12/345 Main St', [
     { unit_type: 'Lot' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assert('U12/345 Main St', [
+  assertFirstParseMatches('U12/345 Main St', [
     { unit_type: 'U' }, { unit: '12' },
     { housenumber: '345' },
     { street: 'Main St' }
   ])
 
-  assert('Lot 12/345 Illawarra Road Marrickville NSW 2204', [
+  assertFirstParseMatches('Lot 12/345 Illawarra Road Marrickville NSW 2204', [
     { unit_type: 'Lot' }, { unit: '12' }, { housenumber: '345' },
     { street: 'Illawarra Road' }, { locality: 'Marrickville' },
     { region: 'NSW' }, { postcode: '2204' }
   ])
 
-  assert('Lot 2, Burrows Avenue, EDMONDSON PARK, NSW, Australia', [
+  assertFirstParseMatches('Lot 2, Burrows Avenue, EDMONDSON PARK, NSW, Australia', [
     { unit_type: 'Lot' }, { unit: '2' },
     { street: 'Burrows Avenue' }, { locality: 'EDMONDSON PARK' },
     { region: 'NSW' }, { country: 'Australia' }

--- a/test/address.cze.test.js
+++ b/test/address.cze.test.js
@@ -1,92 +1,92 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Korunní 810, Praha', [
+  assertFirstParseMatches('Korunní 810, Praha', [
     { street: 'Korunní' }, { housenumber: '810' },
     { locality: 'Praha' }
   ])
 
-  assert('Kájovská 68, Český Krumlov', [
+  assertFirstParseMatches('Kájovská 68, Český Krumlov', [
     { street: 'Kájovská' }, { housenumber: '68' },
     { locality: 'Český Krumlov' }
   ])
 
-  assert('Beethovenova 641/9, Brno', [
+  assertFirstParseMatches('Beethovenova 641/9, Brno', [
     { street: 'Beethovenova' }, { housenumber: '641/9' },
     { locality: 'Brno' }
   ])
 
-  // assert('Ostrava, U Koupaliště 1570/10', [
+  // assertFirstParseMatches('Ostrava, U Koupaliště 1570/10', [
   //   { street: 'U Koupaliště' }, { housenumber: '1570/10' },
   //   { locality: 'Ostrava' }
   // ])
 
-  // assert('Hradec Králové, Karla Čapka 694/5', [
+  // assertFirstParseMatches('Hradec Králové, Karla Čapka 694/5', [
   //   { street: 'Karla Čapka' }, { housenumber: '694/5' },
   //   { locality: 'Hradec Králové' }
   // ])
 
-  // assert('Kolín, Pražská 3', [
+  // assertFirstParseMatches('Kolín, Pražská 3', [
   //   { street: 'Pražská' }, { housenumber: '3' },
   //   { locality: 'Kolín' }
   // ])
 
-  // assert('Neratovice, Jungmannova 676', [
+  // assertFirstParseMatches('Neratovice, Jungmannova 676', [
   //   { street: 'Jungmannova' }, { housenumber: '676' },
   //   { locality: 'Neratovice' }
   // ])
 
-  // assert('Králíky, Bedřicha Smetany 561', [
+  // assertFirstParseMatches('Králíky, Bedřicha Smetany 561', [
   //   { street: 'Bedřicha Smetany' }, { housenumber: '561' },
   //   { locality: 'Králíky' }
   // ])
 
-  // assert('Prachatice, Dlouhá 93', [
+  // assertFirstParseMatches('Prachatice, Dlouhá 93', [
   //   { street: 'Dlouhá' }, { housenumber: '93' },
   //   { locality: 'Prachatice' }
   // ])
 
-  // assert('Ronov nad Doubravou, Nábřežní 180', [
+  // assertFirstParseMatches('Ronov nad Doubravou, Nábřežní 180', [
   //   { street: 'Nábřežní' }, { housenumber: '180' },
   //   { locality: 'Ronov nad Doubravou' }
   // ])
 
-  // assert('Brno, Orlí 517/22', [
+  // assertFirstParseMatches('Brno, Orlí 517/22', [
   //   { street: 'Orlí' }, { housenumber: '517/22' },
   //   { locality: 'Brno' }
   // ])
 
-  // assert('Nový Jičín, Dvořákova 713/11', [
+  // assertFirstParseMatches('Nový Jičín, Dvořákova 713/11', [
   //   { street: 'Dvořákova' }, { housenumber: '713/11' },
   //   { locality: 'Nový Jičín' }
   // ])
 
-  // assert('Praha, V Šáreckém údolí 53/27', [
+  // assertFirstParseMatches('Praha, V Šáreckém údolí 53/27', [
   //   { street: 'V Šáreckém údolí' }, { housenumber: '53/27' },
   //   { locality: 'Praha' }
   // ])
 
-  // assert('Praha, Nad Panenskou 164/4', [
+  // assertFirstParseMatches('Praha, Nad Panenskou 164/4', [
   //   { street: 'Nad Panenskou' }, { housenumber: '164/4' },
   //   { locality: 'Praha' }
   // ])
 
-  // assert('Rožmitál pod Třemšínem, Kpt. Jaroše 403', [
+  // assertFirstParseMatches('Rožmitál pod Třemšínem, Kpt. Jaroše 403', [
   //   { street: 'Kpt. Jaroše' }, { housenumber: '403' },
   //   { locality: 'Rožmitál pod Třemšínem' }
   // ])
 
-  // assert('Klatovy, Jiráskova 15', [
+  // assertFirstParseMatches('Klatovy, Jiráskova 15', [
   //   { street: 'Jiráskova' }, { housenumber: '15' },
   //   { locality: 'Klatovy' }
   // ])
 
-  // assert('Frýdek-Místek, Radniční 1244', [
+  // assertFirstParseMatches('Frýdek-Místek, Radniční 1244', [
   //   { street: 'Radniční' }, { housenumber: '1244' },
   //   { locality: 'Frýdek-Místek' }
   // ])
 
-  // assert('Zlín, Rašínova 70', [
+  // assertFirstParseMatches('Zlín, Rašínova 70', [
   //   { street: 'Rašínova' }, { housenumber: '70' },
   //   { locality: 'Zlín' }
   // ])

--- a/test/address.cze.test.js
+++ b/test/address.cze.test.js
@@ -1,92 +1,92 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Korunní 810, Praha', [
+  assertFirstMatch('Korunní 810, Praha', [
     { street: 'Korunní' }, { housenumber: '810' },
     { locality: 'Praha' }
   ])
 
-  assertFirstParseMatches('Kájovská 68, Český Krumlov', [
+  assertFirstMatch('Kájovská 68, Český Krumlov', [
     { street: 'Kájovská' }, { housenumber: '68' },
     { locality: 'Český Krumlov' }
   ])
 
-  assertFirstParseMatches('Beethovenova 641/9, Brno', [
+  assertFirstMatch('Beethovenova 641/9, Brno', [
     { street: 'Beethovenova' }, { housenumber: '641/9' },
     { locality: 'Brno' }
   ])
 
-  // assertFirstParseMatches('Ostrava, U Koupaliště 1570/10', [
+  // assertFirstMatch('Ostrava, U Koupaliště 1570/10', [
   //   { street: 'U Koupaliště' }, { housenumber: '1570/10' },
   //   { locality: 'Ostrava' }
   // ])
 
-  // assertFirstParseMatches('Hradec Králové, Karla Čapka 694/5', [
+  // assertFirstMatch('Hradec Králové, Karla Čapka 694/5', [
   //   { street: 'Karla Čapka' }, { housenumber: '694/5' },
   //   { locality: 'Hradec Králové' }
   // ])
 
-  // assertFirstParseMatches('Kolín, Pražská 3', [
+  // assertFirstMatch('Kolín, Pražská 3', [
   //   { street: 'Pražská' }, { housenumber: '3' },
   //   { locality: 'Kolín' }
   // ])
 
-  // assertFirstParseMatches('Neratovice, Jungmannova 676', [
+  // assertFirstMatch('Neratovice, Jungmannova 676', [
   //   { street: 'Jungmannova' }, { housenumber: '676' },
   //   { locality: 'Neratovice' }
   // ])
 
-  // assertFirstParseMatches('Králíky, Bedřicha Smetany 561', [
+  // assertFirstMatch('Králíky, Bedřicha Smetany 561', [
   //   { street: 'Bedřicha Smetany' }, { housenumber: '561' },
   //   { locality: 'Králíky' }
   // ])
 
-  // assertFirstParseMatches('Prachatice, Dlouhá 93', [
+  // assertFirstMatch('Prachatice, Dlouhá 93', [
   //   { street: 'Dlouhá' }, { housenumber: '93' },
   //   { locality: 'Prachatice' }
   // ])
 
-  // assertFirstParseMatches('Ronov nad Doubravou, Nábřežní 180', [
+  // assertFirstMatch('Ronov nad Doubravou, Nábřežní 180', [
   //   { street: 'Nábřežní' }, { housenumber: '180' },
   //   { locality: 'Ronov nad Doubravou' }
   // ])
 
-  // assertFirstParseMatches('Brno, Orlí 517/22', [
+  // assertFirstMatch('Brno, Orlí 517/22', [
   //   { street: 'Orlí' }, { housenumber: '517/22' },
   //   { locality: 'Brno' }
   // ])
 
-  // assertFirstParseMatches('Nový Jičín, Dvořákova 713/11', [
+  // assertFirstMatch('Nový Jičín, Dvořákova 713/11', [
   //   { street: 'Dvořákova' }, { housenumber: '713/11' },
   //   { locality: 'Nový Jičín' }
   // ])
 
-  // assertFirstParseMatches('Praha, V Šáreckém údolí 53/27', [
+  // assertFirstMatch('Praha, V Šáreckém údolí 53/27', [
   //   { street: 'V Šáreckém údolí' }, { housenumber: '53/27' },
   //   { locality: 'Praha' }
   // ])
 
-  // assertFirstParseMatches('Praha, Nad Panenskou 164/4', [
+  // assertFirstMatch('Praha, Nad Panenskou 164/4', [
   //   { street: 'Nad Panenskou' }, { housenumber: '164/4' },
   //   { locality: 'Praha' }
   // ])
 
-  // assertFirstParseMatches('Rožmitál pod Třemšínem, Kpt. Jaroše 403', [
+  // assertFirstMatch('Rožmitál pod Třemšínem, Kpt. Jaroše 403', [
   //   { street: 'Kpt. Jaroše' }, { housenumber: '403' },
   //   { locality: 'Rožmitál pod Třemšínem' }
   // ])
 
-  // assertFirstParseMatches('Klatovy, Jiráskova 15', [
+  // assertFirstMatch('Klatovy, Jiráskova 15', [
   //   { street: 'Jiráskova' }, { housenumber: '15' },
   //   { locality: 'Klatovy' }
   // ])
 
-  // assertFirstParseMatches('Frýdek-Místek, Radniční 1244', [
+  // assertFirstMatch('Frýdek-Místek, Radniční 1244', [
   //   { street: 'Radniční' }, { housenumber: '1244' },
   //   { locality: 'Frýdek-Místek' }
   // ])
 
-  // assertFirstParseMatches('Zlín, Rašínova 70', [
+  // assertFirstMatch('Zlín, Rašínova 70', [
   //   { street: 'Rašínova' }, { housenumber: '70' },
   //   { locality: 'Zlín' }
   // ])

--- a/test/address.cze.test.js
+++ b/test/address.cze.test.js
@@ -1,92 +1,92 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Korunní 810, Praha', [
+  assertFirstSolution('Korunní 810, Praha', [
     { street: 'Korunní' }, { housenumber: '810' },
     { locality: 'Praha' }
   ])
 
-  assertFirstMatch('Kájovská 68, Český Krumlov', [
+  assertFirstSolution('Kájovská 68, Český Krumlov', [
     { street: 'Kájovská' }, { housenumber: '68' },
     { locality: 'Český Krumlov' }
   ])
 
-  assertFirstMatch('Beethovenova 641/9, Brno', [
+  assertFirstSolution('Beethovenova 641/9, Brno', [
     { street: 'Beethovenova' }, { housenumber: '641/9' },
     { locality: 'Brno' }
   ])
 
-  // assertFirstMatch('Ostrava, U Koupaliště 1570/10', [
+  // assertFirstSolution('Ostrava, U Koupaliště 1570/10', [
   //   { street: 'U Koupaliště' }, { housenumber: '1570/10' },
   //   { locality: 'Ostrava' }
   // ])
 
-  // assertFirstMatch('Hradec Králové, Karla Čapka 694/5', [
+  // assertFirstSolution('Hradec Králové, Karla Čapka 694/5', [
   //   { street: 'Karla Čapka' }, { housenumber: '694/5' },
   //   { locality: 'Hradec Králové' }
   // ])
 
-  // assertFirstMatch('Kolín, Pražská 3', [
+  // assertFirstSolution('Kolín, Pražská 3', [
   //   { street: 'Pražská' }, { housenumber: '3' },
   //   { locality: 'Kolín' }
   // ])
 
-  // assertFirstMatch('Neratovice, Jungmannova 676', [
+  // assertFirstSolution('Neratovice, Jungmannova 676', [
   //   { street: 'Jungmannova' }, { housenumber: '676' },
   //   { locality: 'Neratovice' }
   // ])
 
-  // assertFirstMatch('Králíky, Bedřicha Smetany 561', [
+  // assertFirstSolution('Králíky, Bedřicha Smetany 561', [
   //   { street: 'Bedřicha Smetany' }, { housenumber: '561' },
   //   { locality: 'Králíky' }
   // ])
 
-  // assertFirstMatch('Prachatice, Dlouhá 93', [
+  // assertFirstSolution('Prachatice, Dlouhá 93', [
   //   { street: 'Dlouhá' }, { housenumber: '93' },
   //   { locality: 'Prachatice' }
   // ])
 
-  // assertFirstMatch('Ronov nad Doubravou, Nábřežní 180', [
+  // assertFirstSolution('Ronov nad Doubravou, Nábřežní 180', [
   //   { street: 'Nábřežní' }, { housenumber: '180' },
   //   { locality: 'Ronov nad Doubravou' }
   // ])
 
-  // assertFirstMatch('Brno, Orlí 517/22', [
+  // assertFirstSolution('Brno, Orlí 517/22', [
   //   { street: 'Orlí' }, { housenumber: '517/22' },
   //   { locality: 'Brno' }
   // ])
 
-  // assertFirstMatch('Nový Jičín, Dvořákova 713/11', [
+  // assertFirstSolution('Nový Jičín, Dvořákova 713/11', [
   //   { street: 'Dvořákova' }, { housenumber: '713/11' },
   //   { locality: 'Nový Jičín' }
   // ])
 
-  // assertFirstMatch('Praha, V Šáreckém údolí 53/27', [
+  // assertFirstSolution('Praha, V Šáreckém údolí 53/27', [
   //   { street: 'V Šáreckém údolí' }, { housenumber: '53/27' },
   //   { locality: 'Praha' }
   // ])
 
-  // assertFirstMatch('Praha, Nad Panenskou 164/4', [
+  // assertFirstSolution('Praha, Nad Panenskou 164/4', [
   //   { street: 'Nad Panenskou' }, { housenumber: '164/4' },
   //   { locality: 'Praha' }
   // ])
 
-  // assertFirstMatch('Rožmitál pod Třemšínem, Kpt. Jaroše 403', [
+  // assertFirstSolution('Rožmitál pod Třemšínem, Kpt. Jaroše 403', [
   //   { street: 'Kpt. Jaroše' }, { housenumber: '403' },
   //   { locality: 'Rožmitál pod Třemšínem' }
   // ])
 
-  // assertFirstMatch('Klatovy, Jiráskova 15', [
+  // assertFirstSolution('Klatovy, Jiráskova 15', [
   //   { street: 'Jiráskova' }, { housenumber: '15' },
   //   { locality: 'Klatovy' }
   // ])
 
-  // assertFirstMatch('Frýdek-Místek, Radniční 1244', [
+  // assertFirstSolution('Frýdek-Místek, Radniční 1244', [
   //   { street: 'Radniční' }, { housenumber: '1244' },
   //   { locality: 'Frýdek-Místek' }
   // ])
 
-  // assertFirstMatch('Zlín, Rašínova 70', [
+  // assertFirstSolution('Zlín, Rašínova 70', [
   //   { street: 'Rašínova' }, { housenumber: '70' },
   //   { locality: 'Zlín' }
   // ])

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -1,62 +1,62 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Am Falkpl. 5, 10437 Berlin', [
+  assertFirstMatch('Am Falkpl. 5, 10437 Berlin', [
     { street: 'Am Falkpl.' }, { housenumber: '5' },
     { postcode: '10437' }, { locality: 'Berlin' }
   ])
 
-  assertFirstParseMatches('Am Nordkanal 11, 47877 Willich', [
+  assertFirstMatch('Am Nordkanal 11, 47877 Willich', [
     { street: 'Am Nordkanal' }, { housenumber: '11' },
     { postcode: '47877' }, { locality: 'Willich' }
   ])
 
-  assertFirstParseMatches('Am Bürgerpark 15-18, 13156, Berlin', [
+  assertFirstMatch('Am Bürgerpark 15-18, 13156, Berlin', [
     { street: 'Am Bürgerpark' }, { housenumber: '15-18' },
     { postcode: '13156' }, { locality: 'Berlin' }
   ])
 
-  assertFirstParseMatches('Kaschk Bar, Linienstraße 40 10119 Berlin', [
+  assertFirstMatch('Kaschk Bar, Linienstraße 40 10119 Berlin', [
     { place: 'Kaschk Bar' },
     { street: 'Linienstraße' }, { housenumber: '40' },
     { postcode: '10119' }, { locality: 'Berlin' }
   ])
 
-  assertFirstParseMatches('Genter Straße 16a, Munich, Germany', [
+  assertFirstMatch('Genter Straße 16a, Munich, Germany', [
     { street: 'Genter Straße' }, { housenumber: '16a' },
     { locality: 'Munich' }, { country: 'Germany' }
   ])
 
-  assertFirstParseMatches('Esplanade 17, Berlin', [
+  assertFirstMatch('Esplanade 17, Berlin', [
     { street: 'Esplanade' }, { housenumber: '17' },
     { locality: 'Berlin' }
   ])
 
-  assertFirstParseMatches('Königsallee Düsseldorf', [
+  assertFirstMatch('Königsallee Düsseldorf', [
     { street: 'Königsallee' },
     { locality: 'Düsseldorf' }
   ])
 
-  assertFirstParseMatches('Rathausplatz', [{ street: 'Rathausplatz' }])
-  assertFirstParseMatches('Plutoweg', [{ street: 'Plutoweg' }])
-  assertFirstParseMatches('Dorfstrasse', [{ street: 'Dorfstrasse' }])
+  assertFirstMatch('Rathausplatz', [{ street: 'Rathausplatz' }])
+  assertFirstMatch('Plutoweg', [{ street: 'Plutoweg' }])
+  assertFirstMatch('Dorfstrasse', [{ street: 'Dorfstrasse' }])
 
   // autocomplete-style query includes partial postcode
-  assertFirstParseMatches('Eberswalder Straße 100 104', [
+  assertFirstMatch('Eberswalder Straße 100 104', [
     { street: 'Eberswalder Straße' }, { housenumber: '100' }
   ])
 
   // addresses on numbered streets in europe
-  assertFirstParseMatches('25 Straße 50', [
+  assertFirstMatch('25 Straße 50', [
     { street: '25 Straße' }, { housenumber: '50' }
   ])
-  assertFirstParseMatches('25 Straße, 50', [
+  assertFirstMatch('25 Straße, 50', [
     { street: '25 Straße' }, { housenumber: '50' }
   ])
-  assertFirstParseMatches('25 Strada 50', [
+  assertFirstMatch('25 Strada 50', [
     { street: '25 Strada' }, { housenumber: '50' }
   ])
-  assertFirstParseMatches('25 Strada, 50', [
+  assertFirstMatch('25 Strada, 50', [
     { street: '25 Strada' }, { housenumber: '50' }
   ])
 }

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -1,62 +1,62 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Am Falkpl. 5, 10437 Berlin', [
+  assertFirstParseMatches('Am Falkpl. 5, 10437 Berlin', [
     { street: 'Am Falkpl.' }, { housenumber: '5' },
     { postcode: '10437' }, { locality: 'Berlin' }
   ])
 
-  assert('Am Nordkanal 11, 47877 Willich', [
+  assertFirstParseMatches('Am Nordkanal 11, 47877 Willich', [
     { street: 'Am Nordkanal' }, { housenumber: '11' },
     { postcode: '47877' }, { locality: 'Willich' }
   ])
 
-  assert('Am Bürgerpark 15-18, 13156, Berlin', [
+  assertFirstParseMatches('Am Bürgerpark 15-18, 13156, Berlin', [
     { street: 'Am Bürgerpark' }, { housenumber: '15-18' },
     { postcode: '13156' }, { locality: 'Berlin' }
   ])
 
-  assert('Kaschk Bar, Linienstraße 40 10119 Berlin', [
+  assertFirstParseMatches('Kaschk Bar, Linienstraße 40 10119 Berlin', [
     { place: 'Kaschk Bar' },
     { street: 'Linienstraße' }, { housenumber: '40' },
     { postcode: '10119' }, { locality: 'Berlin' }
   ])
 
-  assert('Genter Straße 16a, Munich, Germany', [
+  assertFirstParseMatches('Genter Straße 16a, Munich, Germany', [
     { street: 'Genter Straße' }, { housenumber: '16a' },
     { locality: 'Munich' }, { country: 'Germany' }
   ])
 
-  assert('Esplanade 17, Berlin', [
+  assertFirstParseMatches('Esplanade 17, Berlin', [
     { street: 'Esplanade' }, { housenumber: '17' },
     { locality: 'Berlin' }
   ])
 
-  assert('Königsallee Düsseldorf', [
+  assertFirstParseMatches('Königsallee Düsseldorf', [
     { street: 'Königsallee' },
     { locality: 'Düsseldorf' }
   ])
 
-  assert('Rathausplatz', [{ street: 'Rathausplatz' }])
-  assert('Plutoweg', [{ street: 'Plutoweg' }])
-  assert('Dorfstrasse', [{ street: 'Dorfstrasse' }])
+  assertFirstParseMatches('Rathausplatz', [{ street: 'Rathausplatz' }])
+  assertFirstParseMatches('Plutoweg', [{ street: 'Plutoweg' }])
+  assertFirstParseMatches('Dorfstrasse', [{ street: 'Dorfstrasse' }])
 
   // autocomplete-style query includes partial postcode
-  assert('Eberswalder Straße 100 104', [
+  assertFirstParseMatches('Eberswalder Straße 100 104', [
     { street: 'Eberswalder Straße' }, { housenumber: '100' }
   ])
 
   // addresses on numbered streets in europe
-  assert('25 Straße 50', [
+  assertFirstParseMatches('25 Straße 50', [
     { street: '25 Straße' }, { housenumber: '50' }
   ])
-  assert('25 Straße, 50', [
+  assertFirstParseMatches('25 Straße, 50', [
     { street: '25 Straße' }, { housenumber: '50' }
   ])
-  assert('25 Strada 50', [
+  assertFirstParseMatches('25 Strada 50', [
     { street: '25 Strada' }, { housenumber: '50' }
   ])
-  assert('25 Strada, 50', [
+  assertFirstParseMatches('25 Strada, 50', [
     { street: '25 Strada' }, { housenumber: '50' }
   ])
 }

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -1,62 +1,62 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Am Falkpl. 5, 10437 Berlin', [
+  assertFirstSolution('Am Falkpl. 5, 10437 Berlin', [
     { street: 'Am Falkpl.' }, { housenumber: '5' },
     { postcode: '10437' }, { locality: 'Berlin' }
   ])
 
-  assertFirstMatch('Am Nordkanal 11, 47877 Willich', [
+  assertFirstSolution('Am Nordkanal 11, 47877 Willich', [
     { street: 'Am Nordkanal' }, { housenumber: '11' },
     { postcode: '47877' }, { locality: 'Willich' }
   ])
 
-  assertFirstMatch('Am Bürgerpark 15-18, 13156, Berlin', [
+  assertFirstSolution('Am Bürgerpark 15-18, 13156, Berlin', [
     { street: 'Am Bürgerpark' }, { housenumber: '15-18' },
     { postcode: '13156' }, { locality: 'Berlin' }
   ])
 
-  assertFirstMatch('Kaschk Bar, Linienstraße 40 10119 Berlin', [
+  assertFirstSolution('Kaschk Bar, Linienstraße 40 10119 Berlin', [
     { place: 'Kaschk Bar' },
     { street: 'Linienstraße' }, { housenumber: '40' },
     { postcode: '10119' }, { locality: 'Berlin' }
   ])
 
-  assertFirstMatch('Genter Straße 16a, Munich, Germany', [
+  assertFirstSolution('Genter Straße 16a, Munich, Germany', [
     { street: 'Genter Straße' }, { housenumber: '16a' },
     { locality: 'Munich' }, { country: 'Germany' }
   ])
 
-  assertFirstMatch('Esplanade 17, Berlin', [
+  assertFirstSolution('Esplanade 17, Berlin', [
     { street: 'Esplanade' }, { housenumber: '17' },
     { locality: 'Berlin' }
   ])
 
-  assertFirstMatch('Königsallee Düsseldorf', [
+  assertFirstSolution('Königsallee Düsseldorf', [
     { street: 'Königsallee' },
     { locality: 'Düsseldorf' }
   ])
 
-  assertFirstMatch('Rathausplatz', [{ street: 'Rathausplatz' }])
-  assertFirstMatch('Plutoweg', [{ street: 'Plutoweg' }])
-  assertFirstMatch('Dorfstrasse', [{ street: 'Dorfstrasse' }])
+  assertFirstSolution('Rathausplatz', [{ street: 'Rathausplatz' }])
+  assertFirstSolution('Plutoweg', [{ street: 'Plutoweg' }])
+  assertFirstSolution('Dorfstrasse', [{ street: 'Dorfstrasse' }])
 
   // autocomplete-style query includes partial postcode
-  assertFirstMatch('Eberswalder Straße 100 104', [
+  assertFirstSolution('Eberswalder Straße 100 104', [
     { street: 'Eberswalder Straße' }, { housenumber: '100' }
   ])
 
   // addresses on numbered streets in europe
-  assertFirstMatch('25 Straße 50', [
+  assertFirstSolution('25 Straße 50', [
     { street: '25 Straße' }, { housenumber: '50' }
   ])
-  assertFirstMatch('25 Straße, 50', [
+  assertFirstSolution('25 Straße, 50', [
     { street: '25 Straße' }, { housenumber: '50' }
   ])
-  assertFirstMatch('25 Strada 50', [
+  assertFirstSolution('25 Strada 50', [
     { street: '25 Strada' }, { housenumber: '50' }
   ])
-  assertFirstMatch('25 Strada, 50', [
+  assertFirstSolution('25 Strada, 50', [
     { street: '25 Strada' }, { housenumber: '50' }
   ])
 }

--- a/test/address.esp.test.js
+++ b/test/address.esp.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Carrer d\'Aragó 155 08011 Barcelona', [
+  assertFirstParseMatches('Carrer d\'Aragó 155 08011 Barcelona', [
     { street: 'Carrer d\'Aragó' }, { housenumber: '155' },
     { postcode: '08011' }, { locality: 'Barcelona' }
   ])

--- a/test/address.esp.test.js
+++ b/test/address.esp.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Carrer d\'Aragó 155 08011 Barcelona', [
+  assertFirstMatch('Carrer d\'Aragó 155 08011 Barcelona', [
     { street: 'Carrer d\'Aragó' }, { housenumber: '155' },
     { postcode: '08011' }, { locality: 'Barcelona' }
   ])

--- a/test/address.esp.test.js
+++ b/test/address.esp.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Carrer d\'Aragó 155 08011 Barcelona', [
+  assertFirstSolution('Carrer d\'Aragó 155 08011 Barcelona', [
     { street: 'Carrer d\'Aragó' }, { housenumber: '155' },
     { postcode: '08011' }, { locality: 'Barcelona' }
   ])

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -1,115 +1,115 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Rue Montmartre', [
+  assertFirstParseMatches('Rue Montmartre', [
     { street: 'Rue Montmartre' }
   ])
 
-  assert('123 Rue Montmartre, Paris', [
+  assertFirstParseMatches('123 Rue Montmartre, Paris', [
     { housenumber: '123' }, { street: 'Rue Montmartre' }, { locality: 'Paris' }
   ])
 
-  assert('Rue de Paris', [
+  assertFirstParseMatches('Rue de Paris', [
     { street: 'Rue de Paris' }
   ])
 
-  assert('Rue de la Paix', [
+  assertFirstParseMatches('Rue de la Paix', [
     { street: 'Rue de la Paix' }
   ])
 
-  assert('Boulevard du Général Charles De Gaulle', [
+  assertFirstParseMatches('Boulevard du Général Charles De Gaulle', [
     { street: 'Boulevard du Général Charles De Gaulle' }
   ])
 
-  assert('11 Boulevard Saint Germains', [
+  assertFirstParseMatches('11 Boulevard Saint Germains', [
     { housenumber: '11' }, { street: 'Boulevard Saint Germains' }
   ])
 
-  assert('Rue Saint Anne', [
+  assertFirstParseMatches('Rue Saint Anne', [
     { street: 'Rue Saint Anne' }
   ])
 
-  assert('Boulevard Charles De Gaulle', [
+  assertFirstParseMatches('Boulevard Charles De Gaulle', [
     { street: 'Boulevard Charles De Gaulle' }
   ])
 
-  assert('Allée Victor Hugo', [
+  assertFirstParseMatches('Allée Victor Hugo', [
     { street: 'Allée Victor Hugo' }
   ])
 
-  assert('Avenue Aristide Briand', [
+  assertFirstParseMatches('Avenue Aristide Briand', [
     { street: 'Avenue Aristide Briand' }
   ])
 
-  assert('Rue Henri Barbusse Paris France', [
+  assertFirstParseMatches('Rue Henri Barbusse Paris France', [
     { street: 'Rue Henri Barbusse' }, { locality: 'Paris' }, { country: 'France' }
   ])
 
-  assert('Rue du Général Leclerc Dunkerque France', [
+  assertFirstParseMatches('Rue du Général Leclerc Dunkerque France', [
     { street: 'Rue du Général Leclerc' }, { locality: 'Dunkerque' }, { country: 'France' }
   ])
 
-  assert('Avenue de Sainte Rose de Lima', [
+  assertFirstParseMatches('Avenue de Sainte Rose de Lima', [
     { street: 'Avenue de Sainte Rose de Lima' }
   ])
 
-  assert('Rue du Capitaine Galinat Marseille France', [
+  assertFirstParseMatches('Rue du Capitaine Galinat Marseille France', [
     { street: 'Rue du Capitaine Galinat' }, { locality: 'Marseille' }, { country: 'France' }
   ])
 
-  assert('Rue Jean Baptiste Clément', [
+  assertFirstParseMatches('Rue Jean Baptiste Clément', [
     { street: 'Rue Jean Baptiste Clément' }
   ])
 
-  assert('Mery Sur Oise', [
+  assertFirstParseMatches('Mery Sur Oise', [
     { locality: 'Mery Sur Oise' }
   ])
 
-  assert('Méry Sur Oise', [
+  assertFirstParseMatches('Méry Sur Oise', [
     { locality: 'Méry Sur Oise' }
   ])
 
-  assert('Méry-Sur-Oise', [
+  assertFirstParseMatches('Méry-Sur-Oise', [
     { locality: 'Méry-Sur-Oise' }
   ])
 
-  assert('Mery-Sur-Oise', [
+  assertFirstParseMatches('Mery-Sur-Oise', [
     { locality: 'Mery-Sur-Oise' }
   ])
 
-  assert('4 Cité Du Cardinal Lemoine 75005 Paris', [
+  assertFirstParseMatches('4 Cité Du Cardinal Lemoine 75005 Paris', [
     { housenumber: '4' }, { street: 'Cité Du Cardinal Lemoine' }, { postcode: '75005' }, { locality: 'Paris' }
   ])
 
-  assert('32 Rue Du 4 Septembre', [
+  assertFirstParseMatches('32 Rue Du 4 Septembre', [
     { housenumber: '32' }, { street: 'Rue Du 4 Septembre' }
   ])
 
-  assert('12 Cité Roland Garros', [
+  assertFirstParseMatches('12 Cité Roland Garros', [
     { housenumber: '12' }, { street: 'Cité Roland Garros' }
   ])
 
-  assert(`Rue de l'Amiral Galache, Toulouse`, [
+  assertFirstParseMatches(`Rue de l'Amiral Galache, Toulouse`, [
     { street: `Rue de l'Amiral Galache` }, { locality: 'Toulouse' }
   ])
 
-  assert(`Rue de l'Inspecteur Alles Paris`, [
+  assertFirstParseMatches(`Rue de l'Inspecteur Alles Paris`, [
     { street: `Rue de l'Inspecteur Alles` }, { locality: 'Paris' }
   ])
 
-  assert(`Rue de l'Empereur Julien Paris`, [
+  assertFirstParseMatches(`Rue de l'Empereur Julien Paris`, [
     { street: `Rue de l'Empereur Julien` }, { locality: 'Paris' }
   ])
 
-  assert(`Rue de l'Adjudant Réau Paris`, [
+  assertFirstParseMatches(`Rue de l'Adjudant Réau Paris`, [
     { street: `Rue de l'Adjudant Réau` }, { locality: 'Paris' }
   ])
 
-  assert(`10 Boulevard Saint-Germains Paris`, [
+  assertFirstParseMatches(`10 Boulevard Saint-Germains Paris`, [
     { housenumber: '10' }, { street: `Boulevard Saint-Germains` }, { locality: 'Paris' }
   ])
 
-  assert(`Paris 75000, France`, [
+  assertFirstParseMatches(`Paris 75000, France`, [
     { locality: 'Paris' }, { postcode: '75000' }, { country: 'France' }
   ])
 }

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -1,115 +1,115 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Rue Montmartre', [
+  assertFirstMatch('Rue Montmartre', [
     { street: 'Rue Montmartre' }
   ])
 
-  assertFirstParseMatches('123 Rue Montmartre, Paris', [
+  assertFirstMatch('123 Rue Montmartre, Paris', [
     { housenumber: '123' }, { street: 'Rue Montmartre' }, { locality: 'Paris' }
   ])
 
-  assertFirstParseMatches('Rue de Paris', [
+  assertFirstMatch('Rue de Paris', [
     { street: 'Rue de Paris' }
   ])
 
-  assertFirstParseMatches('Rue de la Paix', [
+  assertFirstMatch('Rue de la Paix', [
     { street: 'Rue de la Paix' }
   ])
 
-  assertFirstParseMatches('Boulevard du Général Charles De Gaulle', [
+  assertFirstMatch('Boulevard du Général Charles De Gaulle', [
     { street: 'Boulevard du Général Charles De Gaulle' }
   ])
 
-  assertFirstParseMatches('11 Boulevard Saint Germains', [
+  assertFirstMatch('11 Boulevard Saint Germains', [
     { housenumber: '11' }, { street: 'Boulevard Saint Germains' }
   ])
 
-  assertFirstParseMatches('Rue Saint Anne', [
+  assertFirstMatch('Rue Saint Anne', [
     { street: 'Rue Saint Anne' }
   ])
 
-  assertFirstParseMatches('Boulevard Charles De Gaulle', [
+  assertFirstMatch('Boulevard Charles De Gaulle', [
     { street: 'Boulevard Charles De Gaulle' }
   ])
 
-  assertFirstParseMatches('Allée Victor Hugo', [
+  assertFirstMatch('Allée Victor Hugo', [
     { street: 'Allée Victor Hugo' }
   ])
 
-  assertFirstParseMatches('Avenue Aristide Briand', [
+  assertFirstMatch('Avenue Aristide Briand', [
     { street: 'Avenue Aristide Briand' }
   ])
 
-  assertFirstParseMatches('Rue Henri Barbusse Paris France', [
+  assertFirstMatch('Rue Henri Barbusse Paris France', [
     { street: 'Rue Henri Barbusse' }, { locality: 'Paris' }, { country: 'France' }
   ])
 
-  assertFirstParseMatches('Rue du Général Leclerc Dunkerque France', [
+  assertFirstMatch('Rue du Général Leclerc Dunkerque France', [
     { street: 'Rue du Général Leclerc' }, { locality: 'Dunkerque' }, { country: 'France' }
   ])
 
-  assertFirstParseMatches('Avenue de Sainte Rose de Lima', [
+  assertFirstMatch('Avenue de Sainte Rose de Lima', [
     { street: 'Avenue de Sainte Rose de Lima' }
   ])
 
-  assertFirstParseMatches('Rue du Capitaine Galinat Marseille France', [
+  assertFirstMatch('Rue du Capitaine Galinat Marseille France', [
     { street: 'Rue du Capitaine Galinat' }, { locality: 'Marseille' }, { country: 'France' }
   ])
 
-  assertFirstParseMatches('Rue Jean Baptiste Clément', [
+  assertFirstMatch('Rue Jean Baptiste Clément', [
     { street: 'Rue Jean Baptiste Clément' }
   ])
 
-  assertFirstParseMatches('Mery Sur Oise', [
+  assertFirstMatch('Mery Sur Oise', [
     { locality: 'Mery Sur Oise' }
   ])
 
-  assertFirstParseMatches('Méry Sur Oise', [
+  assertFirstMatch('Méry Sur Oise', [
     { locality: 'Méry Sur Oise' }
   ])
 
-  assertFirstParseMatches('Méry-Sur-Oise', [
+  assertFirstMatch('Méry-Sur-Oise', [
     { locality: 'Méry-Sur-Oise' }
   ])
 
-  assertFirstParseMatches('Mery-Sur-Oise', [
+  assertFirstMatch('Mery-Sur-Oise', [
     { locality: 'Mery-Sur-Oise' }
   ])
 
-  assertFirstParseMatches('4 Cité Du Cardinal Lemoine 75005 Paris', [
+  assertFirstMatch('4 Cité Du Cardinal Lemoine 75005 Paris', [
     { housenumber: '4' }, { street: 'Cité Du Cardinal Lemoine' }, { postcode: '75005' }, { locality: 'Paris' }
   ])
 
-  assertFirstParseMatches('32 Rue Du 4 Septembre', [
+  assertFirstMatch('32 Rue Du 4 Septembre', [
     { housenumber: '32' }, { street: 'Rue Du 4 Septembre' }
   ])
 
-  assertFirstParseMatches('12 Cité Roland Garros', [
+  assertFirstMatch('12 Cité Roland Garros', [
     { housenumber: '12' }, { street: 'Cité Roland Garros' }
   ])
 
-  assertFirstParseMatches(`Rue de l'Amiral Galache, Toulouse`, [
+  assertFirstMatch(`Rue de l'Amiral Galache, Toulouse`, [
     { street: `Rue de l'Amiral Galache` }, { locality: 'Toulouse' }
   ])
 
-  assertFirstParseMatches(`Rue de l'Inspecteur Alles Paris`, [
+  assertFirstMatch(`Rue de l'Inspecteur Alles Paris`, [
     { street: `Rue de l'Inspecteur Alles` }, { locality: 'Paris' }
   ])
 
-  assertFirstParseMatches(`Rue de l'Empereur Julien Paris`, [
+  assertFirstMatch(`Rue de l'Empereur Julien Paris`, [
     { street: `Rue de l'Empereur Julien` }, { locality: 'Paris' }
   ])
 
-  assertFirstParseMatches(`Rue de l'Adjudant Réau Paris`, [
+  assertFirstMatch(`Rue de l'Adjudant Réau Paris`, [
     { street: `Rue de l'Adjudant Réau` }, { locality: 'Paris' }
   ])
 
-  assertFirstParseMatches(`10 Boulevard Saint-Germains Paris`, [
+  assertFirstMatch(`10 Boulevard Saint-Germains Paris`, [
     { housenumber: '10' }, { street: `Boulevard Saint-Germains` }, { locality: 'Paris' }
   ])
 
-  assertFirstParseMatches(`Paris 75000, France`, [
+  assertFirstMatch(`Paris 75000, France`, [
     { locality: 'Paris' }, { postcode: '75000' }, { country: 'France' }
   ])
 }

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -1,115 +1,115 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Rue Montmartre', [
+  assertFirstSolution('Rue Montmartre', [
     { street: 'Rue Montmartre' }
   ])
 
-  assertFirstMatch('123 Rue Montmartre, Paris', [
+  assertFirstSolution('123 Rue Montmartre, Paris', [
     { housenumber: '123' }, { street: 'Rue Montmartre' }, { locality: 'Paris' }
   ])
 
-  assertFirstMatch('Rue de Paris', [
+  assertFirstSolution('Rue de Paris', [
     { street: 'Rue de Paris' }
   ])
 
-  assertFirstMatch('Rue de la Paix', [
+  assertFirstSolution('Rue de la Paix', [
     { street: 'Rue de la Paix' }
   ])
 
-  assertFirstMatch('Boulevard du Général Charles De Gaulle', [
+  assertFirstSolution('Boulevard du Général Charles De Gaulle', [
     { street: 'Boulevard du Général Charles De Gaulle' }
   ])
 
-  assertFirstMatch('11 Boulevard Saint Germains', [
+  assertFirstSolution('11 Boulevard Saint Germains', [
     { housenumber: '11' }, { street: 'Boulevard Saint Germains' }
   ])
 
-  assertFirstMatch('Rue Saint Anne', [
+  assertFirstSolution('Rue Saint Anne', [
     { street: 'Rue Saint Anne' }
   ])
 
-  assertFirstMatch('Boulevard Charles De Gaulle', [
+  assertFirstSolution('Boulevard Charles De Gaulle', [
     { street: 'Boulevard Charles De Gaulle' }
   ])
 
-  assertFirstMatch('Allée Victor Hugo', [
+  assertFirstSolution('Allée Victor Hugo', [
     { street: 'Allée Victor Hugo' }
   ])
 
-  assertFirstMatch('Avenue Aristide Briand', [
+  assertFirstSolution('Avenue Aristide Briand', [
     { street: 'Avenue Aristide Briand' }
   ])
 
-  assertFirstMatch('Rue Henri Barbusse Paris France', [
+  assertFirstSolution('Rue Henri Barbusse Paris France', [
     { street: 'Rue Henri Barbusse' }, { locality: 'Paris' }, { country: 'France' }
   ])
 
-  assertFirstMatch('Rue du Général Leclerc Dunkerque France', [
+  assertFirstSolution('Rue du Général Leclerc Dunkerque France', [
     { street: 'Rue du Général Leclerc' }, { locality: 'Dunkerque' }, { country: 'France' }
   ])
 
-  assertFirstMatch('Avenue de Sainte Rose de Lima', [
+  assertFirstSolution('Avenue de Sainte Rose de Lima', [
     { street: 'Avenue de Sainte Rose de Lima' }
   ])
 
-  assertFirstMatch('Rue du Capitaine Galinat Marseille France', [
+  assertFirstSolution('Rue du Capitaine Galinat Marseille France', [
     { street: 'Rue du Capitaine Galinat' }, { locality: 'Marseille' }, { country: 'France' }
   ])
 
-  assertFirstMatch('Rue Jean Baptiste Clément', [
+  assertFirstSolution('Rue Jean Baptiste Clément', [
     { street: 'Rue Jean Baptiste Clément' }
   ])
 
-  assertFirstMatch('Mery Sur Oise', [
+  assertFirstSolution('Mery Sur Oise', [
     { locality: 'Mery Sur Oise' }
   ])
 
-  assertFirstMatch('Méry Sur Oise', [
+  assertFirstSolution('Méry Sur Oise', [
     { locality: 'Méry Sur Oise' }
   ])
 
-  assertFirstMatch('Méry-Sur-Oise', [
+  assertFirstSolution('Méry-Sur-Oise', [
     { locality: 'Méry-Sur-Oise' }
   ])
 
-  assertFirstMatch('Mery-Sur-Oise', [
+  assertFirstSolution('Mery-Sur-Oise', [
     { locality: 'Mery-Sur-Oise' }
   ])
 
-  assertFirstMatch('4 Cité Du Cardinal Lemoine 75005 Paris', [
+  assertFirstSolution('4 Cité Du Cardinal Lemoine 75005 Paris', [
     { housenumber: '4' }, { street: 'Cité Du Cardinal Lemoine' }, { postcode: '75005' }, { locality: 'Paris' }
   ])
 
-  assertFirstMatch('32 Rue Du 4 Septembre', [
+  assertFirstSolution('32 Rue Du 4 Septembre', [
     { housenumber: '32' }, { street: 'Rue Du 4 Septembre' }
   ])
 
-  assertFirstMatch('12 Cité Roland Garros', [
+  assertFirstSolution('12 Cité Roland Garros', [
     { housenumber: '12' }, { street: 'Cité Roland Garros' }
   ])
 
-  assertFirstMatch(`Rue de l'Amiral Galache, Toulouse`, [
+  assertFirstSolution(`Rue de l'Amiral Galache, Toulouse`, [
     { street: `Rue de l'Amiral Galache` }, { locality: 'Toulouse' }
   ])
 
-  assertFirstMatch(`Rue de l'Inspecteur Alles Paris`, [
+  assertFirstSolution(`Rue de l'Inspecteur Alles Paris`, [
     { street: `Rue de l'Inspecteur Alles` }, { locality: 'Paris' }
   ])
 
-  assertFirstMatch(`Rue de l'Empereur Julien Paris`, [
+  assertFirstSolution(`Rue de l'Empereur Julien Paris`, [
     { street: `Rue de l'Empereur Julien` }, { locality: 'Paris' }
   ])
 
-  assertFirstMatch(`Rue de l'Adjudant Réau Paris`, [
+  assertFirstSolution(`Rue de l'Adjudant Réau Paris`, [
     { street: `Rue de l'Adjudant Réau` }, { locality: 'Paris' }
   ])
 
-  assertFirstMatch(`10 Boulevard Saint-Germains Paris`, [
+  assertFirstSolution(`10 Boulevard Saint-Germains Paris`, [
     { housenumber: '10' }, { street: `Boulevard Saint-Germains` }, { locality: 'Paris' }
   ])
 
-  assertFirstMatch(`Paris 75000, France`, [
+  assertFirstSolution(`Paris 75000, France`, [
     { locality: 'Paris' }, { postcode: '75000' }, { country: 'France' }
   ])
 }

--- a/test/address.gbr.test.js
+++ b/test/address.gbr.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Rushendon Furlong', [
+  assertFirstMatch('Rushendon Furlong', [
     { street: 'Rushendon Furlong' }
   ])
 }

--- a/test/address.gbr.test.js
+++ b/test/address.gbr.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Rushendon Furlong', [
+  assertFirstParseMatches('Rushendon Furlong', [
     { street: 'Rushendon Furlong' }
   ])
 }

--- a/test/address.gbr.test.js
+++ b/test/address.gbr.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Rushendon Furlong', [
+  assertFirstSolution('Rushendon Furlong', [
     { street: 'Rushendon Furlong' }
   ])
 }

--- a/test/address.hrv.test.js
+++ b/test/address.hrv.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Zadarska 17, Pula', [
+  assertFirstMatch('Zadarska 17, Pula', [
     { street: 'Zadarska' }, { housenumber: '17' },
     { locality: 'Pula' }
   ])

--- a/test/address.hrv.test.js
+++ b/test/address.hrv.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Zadarska 17, Pula', [
+  assertFirstParseMatches('Zadarska 17, Pula', [
     { street: 'Zadarska' }, { housenumber: '17' },
     { locality: 'Pula' }
   ])

--- a/test/address.hrv.test.js
+++ b/test/address.hrv.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Zadarska 17, Pula', [
+  assertFirstSolution('Zadarska 17, Pula', [
     { street: 'Zadarska' }, { housenumber: '17' },
     { locality: 'Pula' }
   ])

--- a/test/address.ind.test.js
+++ b/test/address.ind.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('100, Mahalakshmi Rd, Ganesh Nagar, Kirti Nagar, New Sanghavi, Pimpri-Chinchwad, Maharashtra 411027', [
+  assertFirstMatch('100, Mahalakshmi Rd, Ganesh Nagar, Kirti Nagar, New Sanghavi, Pimpri-Chinchwad, Maharashtra 411027', [
     { housenumber: '100' }, { street: 'Mahalakshmi Rd' },
     { locality: 'Pimpri-Chinchwad' }, { region: 'Maharashtra' },
     { postcode: '411027' }

--- a/test/address.ind.test.js
+++ b/test/address.ind.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('100, Mahalakshmi Rd, Ganesh Nagar, Kirti Nagar, New Sanghavi, Pimpri-Chinchwad, Maharashtra 411027', [
+  assertFirstSolution('100, Mahalakshmi Rd, Ganesh Nagar, Kirti Nagar, New Sanghavi, Pimpri-Chinchwad, Maharashtra 411027', [
     { housenumber: '100' }, { street: 'Mahalakshmi Rd' },
     { locality: 'Pimpri-Chinchwad' }, { region: 'Maharashtra' },
     { postcode: '411027' }

--- a/test/address.ind.test.js
+++ b/test/address.ind.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('100, Mahalakshmi Rd, Ganesh Nagar, Kirti Nagar, New Sanghavi, Pimpri-Chinchwad, Maharashtra 411027', [
+  assertFirstParseMatches('100, Mahalakshmi Rd, Ganesh Nagar, Kirti Nagar, New Sanghavi, Pimpri-Chinchwad, Maharashtra 411027', [
     { housenumber: '100' }, { street: 'Mahalakshmi Rd' },
     { locality: 'Pimpri-Chinchwad' }, { region: 'Maharashtra' },
     { postcode: '411027' }

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -1,15 +1,15 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Julianastraat, Heel', [
+  assertFirstParseMatches('Julianastraat, Heel', [
     { street: 'Julianastraat' }, { locality: 'Heel' }
   ])
 
-  assert('Lindenlaan, Sint Odilienberg', [
+  assertFirstParseMatches('Lindenlaan, Sint Odilienberg', [
     { street: 'Lindenlaan' }, { locality: 'Sint Odilienberg' }
   ])
 
-  assert('Bosserdijk, Hoogland', [
+  assertFirstParseMatches('Bosserdijk, Hoogland', [
     { street: 'Bosserdijk' }, { locality: 'Hoogland' }
   ])
 }

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -1,15 +1,15 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Julianastraat, Heel', [
+  assertFirstSolution('Julianastraat, Heel', [
     { street: 'Julianastraat' }, { locality: 'Heel' }
   ])
 
-  assertFirstMatch('Lindenlaan, Sint Odilienberg', [
+  assertFirstSolution('Lindenlaan, Sint Odilienberg', [
     { street: 'Lindenlaan' }, { locality: 'Sint Odilienberg' }
   ])
 
-  assertFirstMatch('Bosserdijk, Hoogland', [
+  assertFirstSolution('Bosserdijk, Hoogland', [
     { street: 'Bosserdijk' }, { locality: 'Hoogland' }
   ])
 }

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -1,15 +1,15 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Julianastraat, Heel', [
+  assertFirstMatch('Julianastraat, Heel', [
     { street: 'Julianastraat' }, { locality: 'Heel' }
   ])
 
-  assertFirstParseMatches('Lindenlaan, Sint Odilienberg', [
+  assertFirstMatch('Lindenlaan, Sint Odilienberg', [
     { street: 'Lindenlaan' }, { locality: 'Sint Odilienberg' }
   ])
 
-  assertFirstParseMatches('Bosserdijk, Hoogland', [
+  assertFirstMatch('Bosserdijk, Hoogland', [
     { street: 'Bosserdijk' }, { locality: 'Hoogland' }
   ])
 }

--- a/test/address.nzd.test.js
+++ b/test/address.nzd.test.js
@@ -1,99 +1,99 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('21 Viaduct Harbour Avenue', [
+  assertFirstParseMatches('21 Viaduct Harbour Avenue', [
     { housenumber: '21' }, { street: 'Viaduct Harbour Avenue' }
   ])
 
-  assert('30 Town Point Road', [
+  assertFirstParseMatches('30 Town Point Road', [
     { housenumber: '30' }, { street: 'Town Point Road' }
   ])
 
-  assert('2 Te Mako Mako Lane', [
+  assertFirstParseMatches('2 Te Mako Mako Lane', [
     { housenumber: '2' }, { street: 'Te Mako Mako Lane' }
   ])
 
-  assert('56 Blue Ridge Drive', [
+  assertFirstParseMatches('56 Blue Ridge Drive', [
     { housenumber: '56' }, { street: 'Blue Ridge Drive' }
   ])
 
-  assert('14 Glen Neaves', [
+  assertFirstParseMatches('14 Glen Neaves', [
     { housenumber: '14' }, { street: 'Glen Neaves' }
   ])
 
-  assert('516 Old Taupo Road', [
+  assertFirstParseMatches('516 Old Taupo Road', [
     { housenumber: '516' }, { street: 'Old Taupo Road' }
   ])
 
-  assert('5658 State Highway 27', [
+  assertFirstParseMatches('5658 State Highway 27', [
     { housenumber: '5658' }, { street: 'State Highway 27' }
   ])
 
-  assert('2 Meadows Lane', [
+  assertFirstParseMatches('2 Meadows Lane', [
     { housenumber: '2' }, { street: 'Meadows Lane' }
   ])
 
-  assert('19 Francis Drake Street', [
+  assertFirstParseMatches('19 Francis Drake Street', [
     { housenumber: '19' }, { street: 'Francis Drake Street' }
   ])
 
-  assert('115-121 Hutt Park Road', [
+  assertFirstParseMatches('115-121 Hutt Park Road', [
     { housenumber: '115-121' }, { street: 'Hutt Park Road' }
   ])
 
-  assert('62 Garden Road', [
+  assertFirstParseMatches('62 Garden Road', [
     { housenumber: '62' }, { street: 'Garden Road' }
   ])
 
-  assert('26 Pine Hill Rise', [
+  assertFirstParseMatches('26 Pine Hill Rise', [
     { housenumber: '26' }, { street: 'Pine Hill Rise' }
   ])
 
-  assert('23 Old Wharf Road', [
+  assertFirstParseMatches('23 Old Wharf Road', [
     { housenumber: '23' }, { street: 'Old Wharf Road' }
   ])
 
-  assert('183 Vista Paku', [
+  assertFirstParseMatches('183 Vista Paku', [
     { housenumber: '183' }, { street: 'Vista Paku' }
   ])
 
-  assert('109 Mathesons Corner Road', [
+  assertFirstParseMatches('109 Mathesons Corner Road', [
     { housenumber: '109' }, { street: 'Mathesons Corner Road' }
   ])
 
-  assert('81 Park Terrace', [
+  assertFirstParseMatches('81 Park Terrace', [
     { housenumber: '81' }, { street: 'Park Terrace' }
   ])
 
-  assert('320 Cannon Hill Crescent', [
+  assertFirstParseMatches('320 Cannon Hill Crescent', [
     { housenumber: '320' }, { street: 'Cannon Hill Crescent' }
   ])
 
-  assert('16 The Stables', [
+  assertFirstParseMatches('16 The Stables', [
     { housenumber: '16' }, { street: 'The Stables' }
   ])
 
-  assert('35 Forbes Road', [
+  assertFirstParseMatches('35 Forbes Road', [
     { housenumber: '35' }, { street: 'Forbes Road' }
   ])
 
-  assert('40 O\'Shannessey Street', [
+  assertFirstParseMatches('40 O\'Shannessey Street', [
     { housenumber: '40' }, { street: 'O\'Shannessey Street' }
   ])
 
-  // assert('37 Hillpark Drive', [
+  // assertFirstParseMatches('37 Hillpark Drive', [
   //   { housenumber: '37' }, { street: 'Hillpark Drive' }
   // ])
 
-  // assert('260 Broadway', [
+  // assertFirstParseMatches('260 Broadway', [
   //   { housenumber: '260' }, { street: 'Broadway' }
   // ])
 
-  // assert('16 Tullamore', [
+  // assertFirstParseMatches('16 Tullamore', [
   //   { housenumber: '16' }, { street: 'Tullamore' }
   // ])
 
-  assert('4207 Mountain Road', [
+  assertFirstParseMatches('4207 Mountain Road', [
     { housenumber: '4207' }, { street: 'Mountain Road' }
   ])
 }

--- a/test/address.nzd.test.js
+++ b/test/address.nzd.test.js
@@ -1,99 +1,99 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('21 Viaduct Harbour Avenue', [
+  assertFirstMatch('21 Viaduct Harbour Avenue', [
     { housenumber: '21' }, { street: 'Viaduct Harbour Avenue' }
   ])
 
-  assertFirstParseMatches('30 Town Point Road', [
+  assertFirstMatch('30 Town Point Road', [
     { housenumber: '30' }, { street: 'Town Point Road' }
   ])
 
-  assertFirstParseMatches('2 Te Mako Mako Lane', [
+  assertFirstMatch('2 Te Mako Mako Lane', [
     { housenumber: '2' }, { street: 'Te Mako Mako Lane' }
   ])
 
-  assertFirstParseMatches('56 Blue Ridge Drive', [
+  assertFirstMatch('56 Blue Ridge Drive', [
     { housenumber: '56' }, { street: 'Blue Ridge Drive' }
   ])
 
-  assertFirstParseMatches('14 Glen Neaves', [
+  assertFirstMatch('14 Glen Neaves', [
     { housenumber: '14' }, { street: 'Glen Neaves' }
   ])
 
-  assertFirstParseMatches('516 Old Taupo Road', [
+  assertFirstMatch('516 Old Taupo Road', [
     { housenumber: '516' }, { street: 'Old Taupo Road' }
   ])
 
-  assertFirstParseMatches('5658 State Highway 27', [
+  assertFirstMatch('5658 State Highway 27', [
     { housenumber: '5658' }, { street: 'State Highway 27' }
   ])
 
-  assertFirstParseMatches('2 Meadows Lane', [
+  assertFirstMatch('2 Meadows Lane', [
     { housenumber: '2' }, { street: 'Meadows Lane' }
   ])
 
-  assertFirstParseMatches('19 Francis Drake Street', [
+  assertFirstMatch('19 Francis Drake Street', [
     { housenumber: '19' }, { street: 'Francis Drake Street' }
   ])
 
-  assertFirstParseMatches('115-121 Hutt Park Road', [
+  assertFirstMatch('115-121 Hutt Park Road', [
     { housenumber: '115-121' }, { street: 'Hutt Park Road' }
   ])
 
-  assertFirstParseMatches('62 Garden Road', [
+  assertFirstMatch('62 Garden Road', [
     { housenumber: '62' }, { street: 'Garden Road' }
   ])
 
-  assertFirstParseMatches('26 Pine Hill Rise', [
+  assertFirstMatch('26 Pine Hill Rise', [
     { housenumber: '26' }, { street: 'Pine Hill Rise' }
   ])
 
-  assertFirstParseMatches('23 Old Wharf Road', [
+  assertFirstMatch('23 Old Wharf Road', [
     { housenumber: '23' }, { street: 'Old Wharf Road' }
   ])
 
-  assertFirstParseMatches('183 Vista Paku', [
+  assertFirstMatch('183 Vista Paku', [
     { housenumber: '183' }, { street: 'Vista Paku' }
   ])
 
-  assertFirstParseMatches('109 Mathesons Corner Road', [
+  assertFirstMatch('109 Mathesons Corner Road', [
     { housenumber: '109' }, { street: 'Mathesons Corner Road' }
   ])
 
-  assertFirstParseMatches('81 Park Terrace', [
+  assertFirstMatch('81 Park Terrace', [
     { housenumber: '81' }, { street: 'Park Terrace' }
   ])
 
-  assertFirstParseMatches('320 Cannon Hill Crescent', [
+  assertFirstMatch('320 Cannon Hill Crescent', [
     { housenumber: '320' }, { street: 'Cannon Hill Crescent' }
   ])
 
-  assertFirstParseMatches('16 The Stables', [
+  assertFirstMatch('16 The Stables', [
     { housenumber: '16' }, { street: 'The Stables' }
   ])
 
-  assertFirstParseMatches('35 Forbes Road', [
+  assertFirstMatch('35 Forbes Road', [
     { housenumber: '35' }, { street: 'Forbes Road' }
   ])
 
-  assertFirstParseMatches('40 O\'Shannessey Street', [
+  assertFirstMatch('40 O\'Shannessey Street', [
     { housenumber: '40' }, { street: 'O\'Shannessey Street' }
   ])
 
-  // assertFirstParseMatches('37 Hillpark Drive', [
+  // assertFirstMatch('37 Hillpark Drive', [
   //   { housenumber: '37' }, { street: 'Hillpark Drive' }
   // ])
 
-  // assertFirstParseMatches('260 Broadway', [
+  // assertFirstMatch('260 Broadway', [
   //   { housenumber: '260' }, { street: 'Broadway' }
   // ])
 
-  // assertFirstParseMatches('16 Tullamore', [
+  // assertFirstMatch('16 Tullamore', [
   //   { housenumber: '16' }, { street: 'Tullamore' }
   // ])
 
-  assertFirstParseMatches('4207 Mountain Road', [
+  assertFirstMatch('4207 Mountain Road', [
     { housenumber: '4207' }, { street: 'Mountain Road' }
   ])
 }

--- a/test/address.nzd.test.js
+++ b/test/address.nzd.test.js
@@ -1,99 +1,99 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('21 Viaduct Harbour Avenue', [
+  assertFirstSolution('21 Viaduct Harbour Avenue', [
     { housenumber: '21' }, { street: 'Viaduct Harbour Avenue' }
   ])
 
-  assertFirstMatch('30 Town Point Road', [
+  assertFirstSolution('30 Town Point Road', [
     { housenumber: '30' }, { street: 'Town Point Road' }
   ])
 
-  assertFirstMatch('2 Te Mako Mako Lane', [
+  assertFirstSolution('2 Te Mako Mako Lane', [
     { housenumber: '2' }, { street: 'Te Mako Mako Lane' }
   ])
 
-  assertFirstMatch('56 Blue Ridge Drive', [
+  assertFirstSolution('56 Blue Ridge Drive', [
     { housenumber: '56' }, { street: 'Blue Ridge Drive' }
   ])
 
-  assertFirstMatch('14 Glen Neaves', [
+  assertFirstSolution('14 Glen Neaves', [
     { housenumber: '14' }, { street: 'Glen Neaves' }
   ])
 
-  assertFirstMatch('516 Old Taupo Road', [
+  assertFirstSolution('516 Old Taupo Road', [
     { housenumber: '516' }, { street: 'Old Taupo Road' }
   ])
 
-  assertFirstMatch('5658 State Highway 27', [
+  assertFirstSolution('5658 State Highway 27', [
     { housenumber: '5658' }, { street: 'State Highway 27' }
   ])
 
-  assertFirstMatch('2 Meadows Lane', [
+  assertFirstSolution('2 Meadows Lane', [
     { housenumber: '2' }, { street: 'Meadows Lane' }
   ])
 
-  assertFirstMatch('19 Francis Drake Street', [
+  assertFirstSolution('19 Francis Drake Street', [
     { housenumber: '19' }, { street: 'Francis Drake Street' }
   ])
 
-  assertFirstMatch('115-121 Hutt Park Road', [
+  assertFirstSolution('115-121 Hutt Park Road', [
     { housenumber: '115-121' }, { street: 'Hutt Park Road' }
   ])
 
-  assertFirstMatch('62 Garden Road', [
+  assertFirstSolution('62 Garden Road', [
     { housenumber: '62' }, { street: 'Garden Road' }
   ])
 
-  assertFirstMatch('26 Pine Hill Rise', [
+  assertFirstSolution('26 Pine Hill Rise', [
     { housenumber: '26' }, { street: 'Pine Hill Rise' }
   ])
 
-  assertFirstMatch('23 Old Wharf Road', [
+  assertFirstSolution('23 Old Wharf Road', [
     { housenumber: '23' }, { street: 'Old Wharf Road' }
   ])
 
-  assertFirstMatch('183 Vista Paku', [
+  assertFirstSolution('183 Vista Paku', [
     { housenumber: '183' }, { street: 'Vista Paku' }
   ])
 
-  assertFirstMatch('109 Mathesons Corner Road', [
+  assertFirstSolution('109 Mathesons Corner Road', [
     { housenumber: '109' }, { street: 'Mathesons Corner Road' }
   ])
 
-  assertFirstMatch('81 Park Terrace', [
+  assertFirstSolution('81 Park Terrace', [
     { housenumber: '81' }, { street: 'Park Terrace' }
   ])
 
-  assertFirstMatch('320 Cannon Hill Crescent', [
+  assertFirstSolution('320 Cannon Hill Crescent', [
     { housenumber: '320' }, { street: 'Cannon Hill Crescent' }
   ])
 
-  assertFirstMatch('16 The Stables', [
+  assertFirstSolution('16 The Stables', [
     { housenumber: '16' }, { street: 'The Stables' }
   ])
 
-  assertFirstMatch('35 Forbes Road', [
+  assertFirstSolution('35 Forbes Road', [
     { housenumber: '35' }, { street: 'Forbes Road' }
   ])
 
-  assertFirstMatch('40 O\'Shannessey Street', [
+  assertFirstSolution('40 O\'Shannessey Street', [
     { housenumber: '40' }, { street: 'O\'Shannessey Street' }
   ])
 
-  // assertFirstMatch('37 Hillpark Drive', [
+  // assertFirstSolution('37 Hillpark Drive', [
   //   { housenumber: '37' }, { street: 'Hillpark Drive' }
   // ])
 
-  // assertFirstMatch('260 Broadway', [
+  // assertFirstSolution('260 Broadway', [
   //   { housenumber: '260' }, { street: 'Broadway' }
   // ])
 
-  // assertFirstMatch('16 Tullamore', [
+  // assertFirstSolution('16 Tullamore', [
   //   { housenumber: '16' }, { street: 'Tullamore' }
   // ])
 
-  assertFirstMatch('4207 Mountain Road', [
+  assertFirstSolution('4207 Mountain Road', [
     { housenumber: '4207' }, { street: 'Mountain Road' }
   ])
 }

--- a/test/address.pol.test.js
+++ b/test/address.pol.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Szewska 6, Kraków', [
+  assertFirstMatch('Szewska 6, Kraków', [
     { street: 'Szewska' }, { housenumber: '6' },
     { locality: 'Kraków' }
   ])

--- a/test/address.pol.test.js
+++ b/test/address.pol.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Szewska 6, Kraków', [
+  assertFirstParseMatches('Szewska 6, Kraków', [
     { street: 'Szewska' }, { housenumber: '6' },
     { locality: 'Kraków' }
   ])

--- a/test/address.pol.test.js
+++ b/test/address.pol.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Szewska 6, Kraków', [
+  assertFirstSolution('Szewska 6, Kraków', [
     { street: 'Szewska' }, { housenumber: '6' },
     { locality: 'Kraków' }
   ])

--- a/test/address.prt.test.js
+++ b/test/address.prt.test.js
@@ -1,30 +1,30 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Rua Luis de Camoes', [
+  assertFirstMatch('Rua Luis de Camoes', [
     { street: 'Rua Luis de Camoes' }
   ])
 
-  assertFirstParseMatches('Rua Padre Cruz 31 3060-187 Cantanhede', [
+  assertFirstMatch('Rua Padre Cruz 31 3060-187 Cantanhede', [
     { street: 'Rua Padre Cruz' }, { housenumber: '31' },
     { postcode: '3060-187' }, { locality: 'Cantanhede' }
   ])
 
-  assertFirstParseMatches('Tv. da Horta 27A', [
+  assertFirstMatch('Tv. da Horta 27A', [
     { street: 'Tv. da Horta' }, { housenumber: '27A' }
   ])
 
-  assertFirstParseMatches('R Academia das Ciências 17C 1200-030 Lisboa', [
+  assertFirstMatch('R Academia das Ciências 17C 1200-030 Lisboa', [
     { street: 'R Academia das Ciências' }, { housenumber: '17C' },
     { postcode: '1200-030' }, { region: 'Lisboa' }
   ])
 
-  assertFirstParseMatches('Rua do Sol a Santa Catarina 17B, 1200-452 Lisboa', [
+  assertFirstMatch('Rua do Sol a Santa Catarina 17B, 1200-452 Lisboa', [
     { street: 'Rua do Sol a Santa Catarina' }, { housenumber: '17B' },
     { postcode: '1200-452' }, { region: 'Lisboa' }
   ])
 
-  assertFirstParseMatches('Tv. dos Fiéis de Deus 12C Lisboa Portugal', [
+  assertFirstMatch('Tv. dos Fiéis de Deus 12C Lisboa Portugal', [
     { street: 'Tv. dos Fiéis de Deus' }, { housenumber: '12C' },
     { region: 'Lisboa' }, { country: 'Portugal' }
   ])

--- a/test/address.prt.test.js
+++ b/test/address.prt.test.js
@@ -1,30 +1,30 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Rua Luis de Camoes', [
+  assertFirstSolution('Rua Luis de Camoes', [
     { street: 'Rua Luis de Camoes' }
   ])
 
-  assertFirstMatch('Rua Padre Cruz 31 3060-187 Cantanhede', [
+  assertFirstSolution('Rua Padre Cruz 31 3060-187 Cantanhede', [
     { street: 'Rua Padre Cruz' }, { housenumber: '31' },
     { postcode: '3060-187' }, { locality: 'Cantanhede' }
   ])
 
-  assertFirstMatch('Tv. da Horta 27A', [
+  assertFirstSolution('Tv. da Horta 27A', [
     { street: 'Tv. da Horta' }, { housenumber: '27A' }
   ])
 
-  assertFirstMatch('R Academia das Ciências 17C 1200-030 Lisboa', [
+  assertFirstSolution('R Academia das Ciências 17C 1200-030 Lisboa', [
     { street: 'R Academia das Ciências' }, { housenumber: '17C' },
     { postcode: '1200-030' }, { region: 'Lisboa' }
   ])
 
-  assertFirstMatch('Rua do Sol a Santa Catarina 17B, 1200-452 Lisboa', [
+  assertFirstSolution('Rua do Sol a Santa Catarina 17B, 1200-452 Lisboa', [
     { street: 'Rua do Sol a Santa Catarina' }, { housenumber: '17B' },
     { postcode: '1200-452' }, { region: 'Lisboa' }
   ])
 
-  assertFirstMatch('Tv. dos Fiéis de Deus 12C Lisboa Portugal', [
+  assertFirstSolution('Tv. dos Fiéis de Deus 12C Lisboa Portugal', [
     { street: 'Tv. dos Fiéis de Deus' }, { housenumber: '12C' },
     { region: 'Lisboa' }, { country: 'Portugal' }
   ])

--- a/test/address.prt.test.js
+++ b/test/address.prt.test.js
@@ -1,30 +1,30 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Rua Luis de Camoes', [
+  assertFirstParseMatches('Rua Luis de Camoes', [
     { street: 'Rua Luis de Camoes' }
   ])
 
-  assert('Rua Padre Cruz 31 3060-187 Cantanhede', [
+  assertFirstParseMatches('Rua Padre Cruz 31 3060-187 Cantanhede', [
     { street: 'Rua Padre Cruz' }, { housenumber: '31' },
     { postcode: '3060-187' }, { locality: 'Cantanhede' }
   ])
 
-  assert('Tv. da Horta 27A', [
+  assertFirstParseMatches('Tv. da Horta 27A', [
     { street: 'Tv. da Horta' }, { housenumber: '27A' }
   ])
 
-  assert('R Academia das Ciências 17C 1200-030 Lisboa', [
+  assertFirstParseMatches('R Academia das Ciências 17C 1200-030 Lisboa', [
     { street: 'R Academia das Ciências' }, { housenumber: '17C' },
     { postcode: '1200-030' }, { region: 'Lisboa' }
   ])
 
-  assert('Rua do Sol a Santa Catarina 17B, 1200-452 Lisboa', [
+  assertFirstParseMatches('Rua do Sol a Santa Catarina 17B, 1200-452 Lisboa', [
     { street: 'Rua do Sol a Santa Catarina' }, { housenumber: '17B' },
     { postcode: '1200-452' }, { region: 'Lisboa' }
   ])
 
-  assert('Tv. dos Fiéis de Deus 12C Lisboa Portugal', [
+  assertFirstParseMatches('Tv. dos Fiéis de Deus 12C Lisboa Portugal', [
     { street: 'Tv. dos Fiéis de Deus' }, { housenumber: '12C' },
     { region: 'Lisboa' }, { country: 'Portugal' }
   ])

--- a/test/address.svk.test.js
+++ b/test/address.svk.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Divadelná 41/3, Trnava', [
+  assertFirstMatch('Divadelná 41/3, Trnava', [
     { street: 'Divadelná' }, { housenumber: '41/3' },
     { locality: 'Trnava' }
   ])

--- a/test/address.svk.test.js
+++ b/test/address.svk.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Divadelná 41/3, Trnava', [
+  assertFirstParseMatches('Divadelná 41/3, Trnava', [
     { street: 'Divadelná' }, { housenumber: '41/3' },
     { locality: 'Trnava' }
   ])

--- a/test/address.svk.test.js
+++ b/test/address.svk.test.js
@@ -1,7 +1,7 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Divadelná 41/3, Trnava', [
+  assertFirstSolution('Divadelná 41/3, Trnava', [
     { street: 'Divadelná' }, { housenumber: '41/3' },
     { locality: 'Trnava' }
   ])

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -1,83 +1,79 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
-  let assertAllMatch = common.assertAllMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
+  let assertFirstSolutions = common.assertFirstSolutions(test)
 
-<<<<<<< HEAD
-  assert('wrigley field',
-    [ [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ], [ { locality: 'field' } ] ],
+  assertFirstSolutions('wrigley field',
+    [ [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ],
     false)
 
-  assert('Martin Luther King Jr. Blvd.', [
-=======
-  assertFirstMatch('Martin Luther King Jr. Blvd.', [
->>>>>>> shorter name!
+  assertFirstSolution('Martin Luther King Jr. Blvd.', [
     { street: 'Martin Luther King Jr. Blvd.' }
   ])
 
-  assertFirstMatch('Martin Luther King Blvd.', [
+  assertFirstSolution('Martin Luther King Blvd.', [
     { street: 'Martin Luther King Blvd.' }
   ])
 
-  assertFirstMatch('1900 SE A ST, SAN FRANCISCO', [
+  assertFirstSolution('1900 SE A ST, SAN FRANCISCO', [
     { housenumber: '1900' }, { street: 'SE A ST' },
     { locality: 'SAN FRANCISCO' }
   ])
 
-  assertFirstMatch('1900 SE F ST, SAN FRANCISCO', [
+  assertFirstSolution('1900 SE F ST, SAN FRANCISCO', [
     { housenumber: '1900' }, { street: 'SE F ST' },
     { locality: 'SAN FRANCISCO' }
   ])
 
-  assertFirstMatch('22024 main st, ca', [
+  assertFirstSolution('22024 main st, ca', [
     { housenumber: '22024' }, { street: 'main st' },
     { region: 'ca' }
   ])
 
   // postcode allowed in first position when only 1 token
-  assertFirstMatch('90210', [{ postcode: '90210' }])
+  assertFirstSolution('90210', [{ postcode: '90210' }])
 
   // postcode allowed in first position when only 1 token in section
-  assertFirstMatch('90210, CA', [{ postcode: '90210' }, { region: 'CA' }])
+  assertFirstSolution('90210, CA', [{ postcode: '90210' }, { region: 'CA' }])
 
   // postcode not allowed in first position otherwise
-  assertAllMatch('90210 Foo', [])
+  assertFirstSolutions('90210 Foo', [])
 
   // autocomplete street name jitter
   // note: we are only testing the street name stays the same throughout
-  assertFirstMatch('N FISKE AVE', [{ street: 'N FISKE AVE' }])
-  assertFirstMatch('N FISKE AVE P', [{ street: 'N FISKE AVE' }])
-  assertFirstMatch('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }])
-  assertFirstMatch('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }])
-  assertFirstMatch('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }])
-  assertFirstMatch('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }])
-  assertFirstMatch('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }])
-  assertFirstMatch('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }])
-  assertFirstMatch('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }])
-  assertFirstMatch('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assertFirstMatch('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }])
-  assertFirstMatch('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assertFirstMatch('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assertFirstMatch('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assertFirstMatch('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
+  assertFirstSolution('N FISKE AVE', [{ street: 'N FISKE AVE' }])
+  assertFirstSolution('N FISKE AVE P', [{ street: 'N FISKE AVE' }])
+  assertFirstSolution('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }])
+  assertFirstSolution('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }])
+  assertFirstSolution('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }])
+  assertFirstSolution('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }])
+  assertFirstSolution('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }])
+  assertFirstSolution('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }])
+  assertFirstSolution('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }])
+  assertFirstSolution('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstSolution('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }])
+  assertFirstSolution('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstSolution('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstSolution('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstSolution('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
 
-  assertFirstMatch('University of Hawaii', [{ place: 'University of Hawaii' }])
+  assertFirstSolution('University of Hawaii', [{ place: 'University of Hawaii' }])
 
   // Maybe one day this test will pass...
   // see: https://github.com/pelias/parser/pull/49
-  // assertFirstMatch('University of Hawaii at Hilo', [
+  // assertFirstSolution('University of Hawaii at Hilo', [
   //   { place: 'University of Hawaii at Hilo' }
   // ])
 
-  assertFirstMatch('Highway 72', [{ street: 'Highway 72' }])
-  assertFirstMatch('1210a Highway 10 W IA', [{ housenumber: '1210a' }, { street: 'Highway 10 W' }, { region: 'IA' }])
-  assertFirstMatch('1210a State Highway 10', [{ housenumber: '1210a' }, { street: 'State Highway 10' }])
-  assertFirstMatch('1389a County Road 42 IA', [{ housenumber: '1389a' }, { street: 'County Road 42' }, { region: 'IA' }])
-  assertFirstMatch('CA 72', [{ street: 'CA 72' }])
-  assertFirstMatch('1210a IA 10 W IA', [{ housenumber: '1210a' }, { street: 'IA 10 W' }, { region: 'IA' }])
-  assertFirstMatch('1210a California 10', [{ housenumber: '1210a' }, { street: 'California 10' }])
-  assertFirstMatch('1389a IA 42 IA', [{ housenumber: '1389a' }, { street: 'IA 42' }, { region: 'IA' }])
+  assertFirstSolution('Highway 72', [{ street: 'Highway 72' }])
+  assertFirstSolution('1210a Highway 10 W IA', [{ housenumber: '1210a' }, { street: 'Highway 10 W' }, { region: 'IA' }])
+  assertFirstSolution('1210a State Highway 10', [{ housenumber: '1210a' }, { street: 'State Highway 10' }])
+  assertFirstSolution('1389a County Road 42 IA', [{ housenumber: '1389a' }, { street: 'County Road 42' }, { region: 'IA' }])
+  assertFirstSolution('CA 72', [{ street: 'CA 72' }])
+  assertFirstSolution('1210a IA 10 W IA', [{ housenumber: '1210a' }, { street: 'IA 10 W' }, { region: 'IA' }])
+  assertFirstSolution('1210a California 10', [{ housenumber: '1210a' }, { street: 'California 10' }])
+  assertFirstSolution('1389a IA 42 IA', [{ housenumber: '1389a' }, { street: 'IA 42' }, { region: 'IA' }])
 
-  assertFirstMatch('1111 MD 760, Lusby, MD, USA', [{ housenumber: '1111' }, { street: 'MD 760' }, { locality: 'Lusby' }, { region: 'MD' }, { country: 'USA' }])
+  assertFirstSolution('1111 MD 760, Lusby, MD, USA', [{ housenumber: '1111' }, { street: 'MD 760' }, { locality: 'Lusby' }, { region: 'MD' }, { country: 'USA' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -2,9 +2,9 @@ const testcase = (test, common) => {
   let assertFirstSolution = common.assertFirstSolution(test)
   let assertFirstSolutions = common.assertFirstSolutions(test)
 
-  assertFirstSolutions('wrigley field',
-    [ [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ],
-    false)
+  assertFirstSolutions('wrigley field', [
+    [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ]
+  ])
 
   assertFirstSolution('Martin Luther King Jr. Blvd.', [
     { street: 'Martin Luther King Jr. Blvd.' }

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -1,79 +1,83 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
-  let assertAllParsesMatch = common.assertAllParsesMatch(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertAllMatch = common.assertAllMatch(test)
 
+<<<<<<< HEAD
   assert('wrigley field',
     [ [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ], [ { locality: 'field' } ] ],
     false)
 
   assert('Martin Luther King Jr. Blvd.', [
+=======
+  assertFirstMatch('Martin Luther King Jr. Blvd.', [
+>>>>>>> shorter name!
     { street: 'Martin Luther King Jr. Blvd.' }
   ])
 
-  assertFirstParseMatches('Martin Luther King Blvd.', [
+  assertFirstMatch('Martin Luther King Blvd.', [
     { street: 'Martin Luther King Blvd.' }
   ])
 
-  assertFirstParseMatches('1900 SE A ST, SAN FRANCISCO', [
+  assertFirstMatch('1900 SE A ST, SAN FRANCISCO', [
     { housenumber: '1900' }, { street: 'SE A ST' },
     { locality: 'SAN FRANCISCO' }
   ])
 
-  assertFirstParseMatches('1900 SE F ST, SAN FRANCISCO', [
+  assertFirstMatch('1900 SE F ST, SAN FRANCISCO', [
     { housenumber: '1900' }, { street: 'SE F ST' },
     { locality: 'SAN FRANCISCO' }
   ])
 
-  assertFirstParseMatches('22024 main st, ca', [
+  assertFirstMatch('22024 main st, ca', [
     { housenumber: '22024' }, { street: 'main st' },
     { region: 'ca' }
   ])
 
   // postcode allowed in first position when only 1 token
-  assertFirstParseMatches('90210', [{ postcode: '90210' }])
+  assertFirstMatch('90210', [{ postcode: '90210' }])
 
   // postcode allowed in first position when only 1 token in section
-  assertFirstParseMatches('90210, CA', [{ postcode: '90210' }, { region: 'CA' }])
+  assertFirstMatch('90210, CA', [{ postcode: '90210' }, { region: 'CA' }])
 
   // postcode not allowed in first position otherwise
-  assertAllParsesMatch('90210 Foo', [])
+  assertAllMatch('90210 Foo', [])
 
   // autocomplete street name jitter
   // note: we are only testing the street name stays the same throughout
-  assertFirstParseMatches('N FISKE AVE', [{ street: 'N FISKE AVE' }])
-  assertFirstParseMatches('N FISKE AVE P', [{ street: 'N FISKE AVE' }])
-  assertFirstParseMatches('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }])
-  assertFirstParseMatches('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }])
-  assertFirstParseMatches('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }])
-  assertFirstParseMatches('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }])
-  assertFirstParseMatches('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }])
-  assertFirstParseMatches('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }])
-  assertFirstParseMatches('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }])
-  assertFirstParseMatches('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assertFirstParseMatches('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }])
-  assertFirstParseMatches('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assertFirstParseMatches('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assertFirstParseMatches('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assertFirstParseMatches('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
+  assertFirstMatch('N FISKE AVE', [{ street: 'N FISKE AVE' }])
+  assertFirstMatch('N FISKE AVE P', [{ street: 'N FISKE AVE' }])
+  assertFirstMatch('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }])
+  assertFirstMatch('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }])
+  assertFirstMatch('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }])
+  assertFirstMatch('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }])
+  assertFirstMatch('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }])
+  assertFirstMatch('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }])
+  assertFirstMatch('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }])
+  assertFirstMatch('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstMatch('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }])
+  assertFirstMatch('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstMatch('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstMatch('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstMatch('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
 
-  assertFirstParseMatches('University of Hawaii', [{ place: 'University of Hawaii' }])
+  assertFirstMatch('University of Hawaii', [{ place: 'University of Hawaii' }])
 
   // Maybe one day this test will pass...
   // see: https://github.com/pelias/parser/pull/49
-  // assertFirstParseMatches('University of Hawaii at Hilo', [
+  // assertFirstMatch('University of Hawaii at Hilo', [
   //   { place: 'University of Hawaii at Hilo' }
   // ])
 
-  assertFirstParseMatches('Highway 72', [{ street: 'Highway 72' }])
-  assertFirstParseMatches('1210a Highway 10 W IA', [{ housenumber: '1210a' }, { street: 'Highway 10 W' }, { region: 'IA' }])
-  assertFirstParseMatches('1210a State Highway 10', [{ housenumber: '1210a' }, { street: 'State Highway 10' }])
-  assertFirstParseMatches('1389a County Road 42 IA', [{ housenumber: '1389a' }, { street: 'County Road 42' }, { region: 'IA' }])
-  assertFirstParseMatches('CA 72', [{ street: 'CA 72' }])
-  assertFirstParseMatches('1210a IA 10 W IA', [{ housenumber: '1210a' }, { street: 'IA 10 W' }, { region: 'IA' }])
-  assertFirstParseMatches('1210a California 10', [{ housenumber: '1210a' }, { street: 'California 10' }])
-  assertFirstParseMatches('1389a IA 42 IA', [{ housenumber: '1389a' }, { street: 'IA 42' }, { region: 'IA' }])
+  assertFirstMatch('Highway 72', [{ street: 'Highway 72' }])
+  assertFirstMatch('1210a Highway 10 W IA', [{ housenumber: '1210a' }, { street: 'Highway 10 W' }, { region: 'IA' }])
+  assertFirstMatch('1210a State Highway 10', [{ housenumber: '1210a' }, { street: 'State Highway 10' }])
+  assertFirstMatch('1389a County Road 42 IA', [{ housenumber: '1389a' }, { street: 'County Road 42' }, { region: 'IA' }])
+  assertFirstMatch('CA 72', [{ street: 'CA 72' }])
+  assertFirstMatch('1210a IA 10 W IA', [{ housenumber: '1210a' }, { street: 'IA 10 W' }, { region: 'IA' }])
+  assertFirstMatch('1210a California 10', [{ housenumber: '1210a' }, { street: 'California 10' }])
+  assertFirstMatch('1389a IA 42 IA', [{ housenumber: '1389a' }, { street: 'IA 42' }, { region: 'IA' }])
 
-  assertFirstParseMatches('1111 MD 760, Lusby, MD, USA', [{ housenumber: '1111' }, { street: 'MD 760' }, { locality: 'Lusby' }, { region: 'MD' }, { country: 'USA' }])
+  assertFirstMatch('1111 MD 760, Lusby, MD, USA', [{ housenumber: '1111' }, { street: 'MD 760' }, { locality: 'Lusby' }, { region: 'MD' }, { country: 'USA' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -1,5 +1,6 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertAllParsesMatch = common.assertAllParsesMatch(test)
 
   assert('wrigley field',
     [ [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ], [ { locality: 'field' } ] ],
@@ -9,70 +10,70 @@ const testcase = (test, common) => {
     { street: 'Martin Luther King Jr. Blvd.' }
   ])
 
-  assert('Martin Luther King Blvd.', [
+  assertFirstParseMatches('Martin Luther King Blvd.', [
     { street: 'Martin Luther King Blvd.' }
   ])
 
-  assert('1900 SE A ST, SAN FRANCISCO', [
+  assertFirstParseMatches('1900 SE A ST, SAN FRANCISCO', [
     { housenumber: '1900' }, { street: 'SE A ST' },
     { locality: 'SAN FRANCISCO' }
   ])
 
-  assert('1900 SE F ST, SAN FRANCISCO', [
+  assertFirstParseMatches('1900 SE F ST, SAN FRANCISCO', [
     { housenumber: '1900' }, { street: 'SE F ST' },
     { locality: 'SAN FRANCISCO' }
   ])
 
-  assert('22024 main st, ca', [
+  assertFirstParseMatches('22024 main st, ca', [
     { housenumber: '22024' }, { street: 'main st' },
     { region: 'ca' }
   ])
 
   // postcode allowed in first position when only 1 token
-  assert('90210', [{ postcode: '90210' }])
+  assertFirstParseMatches('90210', [{ postcode: '90210' }])
 
   // postcode allowed in first position when only 1 token in section
-  assert('90210, CA', [{ postcode: '90210' }, { region: 'CA' }])
+  assertFirstParseMatches('90210, CA', [{ postcode: '90210' }, { region: 'CA' }])
 
   // postcode not allowed in first position otherwise
-  assert('90210 Foo', [], false)
+  assertAllParsesMatch('90210 Foo', [])
 
   // autocomplete street name jitter
   // note: we are only testing the street name stays the same throughout
-  assert('N FISKE AVE', [{ street: 'N FISKE AVE' }])
-  assert('N FISKE AVE P', [{ street: 'N FISKE AVE' }])
-  assert('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }])
-  assert('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }])
-  assert('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }])
-  assert('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }])
-  assert('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }])
-  assert('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }])
-  assert('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }])
-  assert('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assert('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }])
-  assert('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assert('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assert('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
-  assert('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
+  assertFirstParseMatches('N FISKE AVE', [{ street: 'N FISKE AVE' }])
+  assertFirstParseMatches('N FISKE AVE P', [{ street: 'N FISKE AVE' }])
+  assertFirstParseMatches('N FISKE AVE Po', [{ street: 'N FISKE AVE' }, { region: 'Po' }])
+  assertFirstParseMatches('N FISKE AVE Por', [{ street: 'N FISKE AVE' }, { region: 'Por' }])
+  assertFirstParseMatches('N FISKE AVE Port', [{ street: 'N FISKE AVE' }, { locality: 'Port' }])
+  assertFirstParseMatches('N FISKE AVE Portl', [{ street: 'N FISKE AVE' }])
+  assertFirstParseMatches('N FISKE AVE Portla', [{ street: 'N FISKE AVE' }])
+  assertFirstParseMatches('N FISKE AVE Portlan', [{ street: 'N FISKE AVE' }])
+  assertFirstParseMatches('N FISKE AVE Portland', [{ street: 'N FISKE AVE' }, { locality: 'Portland' }])
+  assertFirstParseMatches('N DWIGHT AVE Portland O', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstParseMatches('N DWIGHT AVE Portland Or', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Or' }])
+  assertFirstParseMatches('N DWIGHT AVE Portland Ore', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstParseMatches('N DWIGHT AVE Portland Oreg', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstParseMatches('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
+  assertFirstParseMatches('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
 
-  assert('University of Hawaii', [{ place: 'University of Hawaii' }])
+  assertFirstParseMatches('University of Hawaii', [{ place: 'University of Hawaii' }])
 
   // Maybe one day this test will pass...
   // see: https://github.com/pelias/parser/pull/49
-  // assert('University of Hawaii at Hilo', [
+  // assertFirstParseMatches('University of Hawaii at Hilo', [
   //   { place: 'University of Hawaii at Hilo' }
   // ])
 
-  assert('Highway 72', [{ street: 'Highway 72' }], true)
-  assert('1210a Highway 10 W IA', [{ housenumber: '1210a' }, { street: 'Highway 10 W' }, { region: 'IA' }], true)
-  assert('1210a State Highway 10', [{ housenumber: '1210a' }, { street: 'State Highway 10' }], true)
-  assert('1389a County Road 42 IA', [{ housenumber: '1389a' }, { street: 'County Road 42' }, { region: 'IA' }], true)
-  assert('CA 72', [{ street: 'CA 72' }], true)
-  assert('1210a IA 10 W IA', [{ housenumber: '1210a' }, { street: 'IA 10 W' }, { region: 'IA' }], true)
-  assert('1210a California 10', [{ housenumber: '1210a' }, { street: 'California 10' }], true)
-  assert('1389a IA 42 IA', [{ housenumber: '1389a' }, { street: 'IA 42' }, { region: 'IA' }], true)
+  assertFirstParseMatches('Highway 72', [{ street: 'Highway 72' }])
+  assertFirstParseMatches('1210a Highway 10 W IA', [{ housenumber: '1210a' }, { street: 'Highway 10 W' }, { region: 'IA' }])
+  assertFirstParseMatches('1210a State Highway 10', [{ housenumber: '1210a' }, { street: 'State Highway 10' }])
+  assertFirstParseMatches('1389a County Road 42 IA', [{ housenumber: '1389a' }, { street: 'County Road 42' }, { region: 'IA' }])
+  assertFirstParseMatches('CA 72', [{ street: 'CA 72' }])
+  assertFirstParseMatches('1210a IA 10 W IA', [{ housenumber: '1210a' }, { street: 'IA 10 W' }, { region: 'IA' }])
+  assertFirstParseMatches('1210a California 10', [{ housenumber: '1210a' }, { street: 'California 10' }])
+  assertFirstParseMatches('1389a IA 42 IA', [{ housenumber: '1389a' }, { street: 'IA 42' }, { region: 'IA' }])
 
-  assert('1111 MD 760, Lusby, MD, USA', [{ housenumber: '1111' }, { street: 'MD 760' }, { locality: 'Lusby' }, { region: 'MD' }, { country: 'USA' }], true)
+  assertFirstParseMatches('1111 MD 760, Lusby, MD, USA', [{ housenumber: '1111' }, { street: 'MD 760' }, { locality: 'Lusby' }, { region: 'MD' }, { country: 'USA' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/addressit.aus.test.js
+++ b/test/addressit.aus.test.js
@@ -2,53 +2,53 @@
 // https://github.com/DamonOehlman/addressit/tree/master/test
 
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('2649 Logan Road, Eight Mile Plains, QLD 4113', [
+  assertFirstParseMatches('2649 Logan Road, Eight Mile Plains, QLD 4113', [
     { housenumber: '2649' }, { street: 'Logan Road' },
     { locality: 'Eight Mile Plains' },
     { region: 'QLD' }, { postcode: '4113' }
   ])
 
-  assert('2649 Logan Road Eight Mile Plains, QLD 4113', [
+  assertFirstParseMatches('2649 Logan Road Eight Mile Plains, QLD 4113', [
     { housenumber: '2649' }, { street: 'Logan Road' },
     { locality: 'Eight Mile Plains' },
     { region: 'QLD' }, { postcode: '4113' }
   ])
 
-  assert('1 Queen Street, Brisbane 4000', [
+  assertFirstParseMatches('1 Queen Street, Brisbane 4000', [
     { housenumber: '1' }, { street: 'Queen Street' },
     { locality: 'Brisbane' }, { postcode: '4000' }
   ])
 
-  assert('754 Robinson Rd West, Aspley, QLD 4035', [
+  assertFirstParseMatches('754 Robinson Rd West, Aspley, QLD 4035', [
     { housenumber: '754' }, { street: 'Robinson Rd West' },
     { locality: 'Aspley' }, { region: 'QLD' }, { postcode: '4035' }
   ])
 
-  assert('Sydney 2000', [
+  assertFirstParseMatches('Sydney 2000', [
     { locality: 'Sydney' }, { postcode: '2000' }
   ])
 
-  assert('Perth', [{ locality: 'Perth' }])
+  assertFirstParseMatches('Perth', [{ locality: 'Perth' }])
 
-  assert('1/135 Ferny Way, Ferny Grove 4054', [
+  assertFirstParseMatches('1/135 Ferny Way, Ferny Grove 4054', [
     { housenumber: '1/135' }, { street: 'Ferny Way' },
     { locality: 'Ferny Grove' }, { postcode: '4054' }
   ])
 
-  assert('Eight Mile Plains 4113', [
+  assertFirstParseMatches('Eight Mile Plains 4113', [
     { locality: 'Eight Mile Plains' }, { postcode: '4113' }
   ])
 
-  assert('8/437 St Kilda Road Melbourne, VIC ', [
+  assertFirstParseMatches('8/437 St Kilda Road Melbourne, VIC ', [
     { housenumber: '8/437' }, { street: 'St Kilda Road' },
     { locality: 'Melbourne' }, { region: 'VIC' }
   ])
 
-  assert('BOOM', [{ locality: 'BOOM' }])
+  assertFirstParseMatches('BOOM', [{ locality: 'BOOM' }])
 
-  assert('Eight Mile Plains 9999', [
+  assertFirstParseMatches('Eight Mile Plains 9999', [
     { locality: 'Eight Mile Plains' }, { postcode: '9999' }
   ])
 }

--- a/test/addressit.aus.test.js
+++ b/test/addressit.aus.test.js
@@ -2,53 +2,53 @@
 // https://github.com/DamonOehlman/addressit/tree/master/test
 
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('2649 Logan Road, Eight Mile Plains, QLD 4113', [
+  assertFirstSolution('2649 Logan Road, Eight Mile Plains, QLD 4113', [
     { housenumber: '2649' }, { street: 'Logan Road' },
     { locality: 'Eight Mile Plains' },
     { region: 'QLD' }, { postcode: '4113' }
   ])
 
-  assertFirstMatch('2649 Logan Road Eight Mile Plains, QLD 4113', [
+  assertFirstSolution('2649 Logan Road Eight Mile Plains, QLD 4113', [
     { housenumber: '2649' }, { street: 'Logan Road' },
     { locality: 'Eight Mile Plains' },
     { region: 'QLD' }, { postcode: '4113' }
   ])
 
-  assertFirstMatch('1 Queen Street, Brisbane 4000', [
+  assertFirstSolution('1 Queen Street, Brisbane 4000', [
     { housenumber: '1' }, { street: 'Queen Street' },
     { locality: 'Brisbane' }, { postcode: '4000' }
   ])
 
-  assertFirstMatch('754 Robinson Rd West, Aspley, QLD 4035', [
+  assertFirstSolution('754 Robinson Rd West, Aspley, QLD 4035', [
     { housenumber: '754' }, { street: 'Robinson Rd West' },
     { locality: 'Aspley' }, { region: 'QLD' }, { postcode: '4035' }
   ])
 
-  assertFirstMatch('Sydney 2000', [
+  assertFirstSolution('Sydney 2000', [
     { locality: 'Sydney' }, { postcode: '2000' }
   ])
 
-  assertFirstMatch('Perth', [{ locality: 'Perth' }])
+  assertFirstSolution('Perth', [{ locality: 'Perth' }])
 
-  assertFirstMatch('1/135 Ferny Way, Ferny Grove 4054', [
+  assertFirstSolution('1/135 Ferny Way, Ferny Grove 4054', [
     { housenumber: '1/135' }, { street: 'Ferny Way' },
     { locality: 'Ferny Grove' }, { postcode: '4054' }
   ])
 
-  assertFirstMatch('Eight Mile Plains 4113', [
+  assertFirstSolution('Eight Mile Plains 4113', [
     { locality: 'Eight Mile Plains' }, { postcode: '4113' }
   ])
 
-  assertFirstMatch('8/437 St Kilda Road Melbourne, VIC ', [
+  assertFirstSolution('8/437 St Kilda Road Melbourne, VIC ', [
     { housenumber: '8/437' }, { street: 'St Kilda Road' },
     { locality: 'Melbourne' }, { region: 'VIC' }
   ])
 
-  assertFirstMatch('BOOM', [{ locality: 'BOOM' }])
+  assertFirstSolution('BOOM', [{ locality: 'BOOM' }])
 
-  assertFirstMatch('Eight Mile Plains 9999', [
+  assertFirstSolution('Eight Mile Plains 9999', [
     { locality: 'Eight Mile Plains' }, { postcode: '9999' }
   ])
 }

--- a/test/addressit.aus.test.js
+++ b/test/addressit.aus.test.js
@@ -2,53 +2,53 @@
 // https://github.com/DamonOehlman/addressit/tree/master/test
 
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('2649 Logan Road, Eight Mile Plains, QLD 4113', [
+  assertFirstMatch('2649 Logan Road, Eight Mile Plains, QLD 4113', [
     { housenumber: '2649' }, { street: 'Logan Road' },
     { locality: 'Eight Mile Plains' },
     { region: 'QLD' }, { postcode: '4113' }
   ])
 
-  assertFirstParseMatches('2649 Logan Road Eight Mile Plains, QLD 4113', [
+  assertFirstMatch('2649 Logan Road Eight Mile Plains, QLD 4113', [
     { housenumber: '2649' }, { street: 'Logan Road' },
     { locality: 'Eight Mile Plains' },
     { region: 'QLD' }, { postcode: '4113' }
   ])
 
-  assertFirstParseMatches('1 Queen Street, Brisbane 4000', [
+  assertFirstMatch('1 Queen Street, Brisbane 4000', [
     { housenumber: '1' }, { street: 'Queen Street' },
     { locality: 'Brisbane' }, { postcode: '4000' }
   ])
 
-  assertFirstParseMatches('754 Robinson Rd West, Aspley, QLD 4035', [
+  assertFirstMatch('754 Robinson Rd West, Aspley, QLD 4035', [
     { housenumber: '754' }, { street: 'Robinson Rd West' },
     { locality: 'Aspley' }, { region: 'QLD' }, { postcode: '4035' }
   ])
 
-  assertFirstParseMatches('Sydney 2000', [
+  assertFirstMatch('Sydney 2000', [
     { locality: 'Sydney' }, { postcode: '2000' }
   ])
 
-  assertFirstParseMatches('Perth', [{ locality: 'Perth' }])
+  assertFirstMatch('Perth', [{ locality: 'Perth' }])
 
-  assertFirstParseMatches('1/135 Ferny Way, Ferny Grove 4054', [
+  assertFirstMatch('1/135 Ferny Way, Ferny Grove 4054', [
     { housenumber: '1/135' }, { street: 'Ferny Way' },
     { locality: 'Ferny Grove' }, { postcode: '4054' }
   ])
 
-  assertFirstParseMatches('Eight Mile Plains 4113', [
+  assertFirstMatch('Eight Mile Plains 4113', [
     { locality: 'Eight Mile Plains' }, { postcode: '4113' }
   ])
 
-  assertFirstParseMatches('8/437 St Kilda Road Melbourne, VIC ', [
+  assertFirstMatch('8/437 St Kilda Road Melbourne, VIC ', [
     { housenumber: '8/437' }, { street: 'St Kilda Road' },
     { locality: 'Melbourne' }, { region: 'VIC' }
   ])
 
-  assertFirstParseMatches('BOOM', [{ locality: 'BOOM' }])
+  assertFirstMatch('BOOM', [{ locality: 'BOOM' }])
 
-  assertFirstParseMatches('Eight Mile Plains 9999', [
+  assertFirstMatch('Eight Mile Plains 9999', [
     { locality: 'Eight Mile Plains' }, { postcode: '9999' }
   ])
 }

--- a/test/addressit.usa.test.js
+++ b/test/addressit.usa.test.js
@@ -2,101 +2,101 @@
 // https://github.com/DamonOehlman/addressit/tree/master/test
 
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('123 Main St, New York, NY 10010', [
+  assertFirstMatch('123 Main St, New York, NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assertFirstParseMatches('123 Main St New York, NY 10010', [
+  assertFirstMatch('123 Main St New York, NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assertFirstParseMatches('123 Main St New York NY 10010', [
+  assertFirstMatch('123 Main St New York NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assertFirstParseMatches('123 E 21st st, Brooklyn NY 11020', [
+  assertFirstMatch('123 E 21st st, Brooklyn NY 11020', [
     { housenumber: '123' }, { street: 'E 21st st' },
     { locality: 'Brooklyn' }, { region: 'NY' },
     { postcode: '11020' }
   ])
 
-  assertFirstParseMatches('754 Pharr Rd, Atlanta, Georgia 31035', [
+  assertFirstMatch('754 Pharr Rd, Atlanta, Georgia 31035', [
     { housenumber: '754' }, { street: 'Pharr Rd' },
     { locality: 'Atlanta' }, { region: 'Georgia' },
     { postcode: '31035' }
   ])
 
-  assertFirstParseMatches('601 21st Ave N, Myrtle Beach, South Carolina 29577', [
+  assertFirstMatch('601 21st Ave N, Myrtle Beach, South Carolina 29577', [
     { housenumber: '601' }, { street: '21st Ave N' },
     { locality: 'Myrtle Beach' }, { region: 'South Carolina' },
     { postcode: '29577' }
   ])
 
-  assertFirstParseMatches('425 W 23rd St, New York, NY 10011', [
+  assertFirstMatch('425 W 23rd St, New York, NY 10011', [
     { housenumber: '425' }, { street: 'W 23rd St' },
     { locality: 'New York' }, { region: 'NY' }, { postcode: '10011' }
   ])
 
-  assertFirstParseMatches('1035 Comanchee Trl, West Columbia, South Carolina 29169', [
+  assertFirstMatch('1035 Comanchee Trl, West Columbia, South Carolina 29169', [
     { housenumber: '1035' }, { street: 'Comanchee Trl' },
     { locality: 'West Columbia' }, { region: 'South Carolina' },
     { postcode: '29169' }
   ])
 
-  assertFirstParseMatches('Texas 76013', [{ region: 'Texas' }, { postcode: '76013' }])
+  assertFirstMatch('Texas 76013', [{ region: 'Texas' }, { postcode: '76013' }])
 
-  assertFirstParseMatches('Dallas', [{ locality: 'Dallas' }])
+  assertFirstMatch('Dallas', [{ locality: 'Dallas' }])
 
-  assertFirstParseMatches('California', [{ region: 'California' }])
+  assertFirstMatch('California', [{ region: 'California' }])
 
-  assertFirstParseMatches('New York', [{ locality: 'New York' }])
+  assertFirstMatch('New York', [{ locality: 'New York' }])
 
-  assertFirstParseMatches('New York, NY', [{ locality: 'New York' }, { region: 'NY' }])
+  assertFirstMatch('New York, NY', [{ locality: 'New York' }, { region: 'NY' }])
 
-  assertFirstParseMatches('New York, New York', [
+  assertFirstMatch('New York, New York', [
     { locality: 'New York' }, { region: 'New York' }
   ])
 
-  // assertFirstParseMatches('northern mariana islands', [])
+  // assertFirstMatch('northern mariana islands', [])
 
-  assertFirstParseMatches('Santa Monica, California 90407', [
+  assertFirstMatch('Santa Monica, California 90407', [
     { locality: 'Santa Monica' }, { region: 'California' }, { postcode: '90407' }
   ])
 
-  assertFirstParseMatches('Grand canyon 86023', [
+  assertFirstMatch('Grand canyon 86023', [
     { locality: 'Grand canyon' }, { postcode: '86023' }
   ])
 
-  assertFirstParseMatches('CT, 06410', [{ region: 'CT' }, { postcode: '06410' }])
+  assertFirstMatch('CT, 06410', [{ region: 'CT' }, { postcode: '06410' }])
 
-  assertFirstParseMatches('BOOM', [{ locality: 'BOOM' }])
+  assertFirstMatch('BOOM', [{ locality: 'BOOM' }])
 
-  assertFirstParseMatches('Niagara Falls 76B09', [
+  assertFirstMatch('Niagara Falls 76B09', [
     { locality: 'Niagara Falls' }
   ])
 
-  // assertFirstParseMatches('123 Broadway, New York, NY 10010', [
+  // assertFirstMatch('123 Broadway, New York, NY 10010', [
   //   { street: '123 Broadway' }, { locality: 'New York' }, { region: 'NY' }, { postcode: '10010' }
   // ])
 
-  assertFirstParseMatches('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', [
+  assertFirstMatch('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', [
     { place: 'Mt Tabor Park' },
     { housenumber: '6220' }, { street: 'SE Salmon St' },
     { locality: 'Portland' }, { region: 'OR' },
     { postcode: '97215' }, { country: 'USA' }
   ])
 
-  // assertFirstParseMatches('Mt Tabor Park', [])
+  // assertFirstMatch('Mt Tabor Park', [])
 
-  assertFirstParseMatches('Mt', [{ region: 'Mt' }])
+  assertFirstMatch('Mt', [{ region: 'Mt' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/addressit.usa.test.js
+++ b/test/addressit.usa.test.js
@@ -2,101 +2,101 @@
 // https://github.com/DamonOehlman/addressit/tree/master/test
 
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('123 Main St, New York, NY 10010', [
+  assertFirstSolution('123 Main St, New York, NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assertFirstMatch('123 Main St New York, NY 10010', [
+  assertFirstSolution('123 Main St New York, NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assertFirstMatch('123 Main St New York NY 10010', [
+  assertFirstSolution('123 Main St New York NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assertFirstMatch('123 E 21st st, Brooklyn NY 11020', [
+  assertFirstSolution('123 E 21st st, Brooklyn NY 11020', [
     { housenumber: '123' }, { street: 'E 21st st' },
     { locality: 'Brooklyn' }, { region: 'NY' },
     { postcode: '11020' }
   ])
 
-  assertFirstMatch('754 Pharr Rd, Atlanta, Georgia 31035', [
+  assertFirstSolution('754 Pharr Rd, Atlanta, Georgia 31035', [
     { housenumber: '754' }, { street: 'Pharr Rd' },
     { locality: 'Atlanta' }, { region: 'Georgia' },
     { postcode: '31035' }
   ])
 
-  assertFirstMatch('601 21st Ave N, Myrtle Beach, South Carolina 29577', [
+  assertFirstSolution('601 21st Ave N, Myrtle Beach, South Carolina 29577', [
     { housenumber: '601' }, { street: '21st Ave N' },
     { locality: 'Myrtle Beach' }, { region: 'South Carolina' },
     { postcode: '29577' }
   ])
 
-  assertFirstMatch('425 W 23rd St, New York, NY 10011', [
+  assertFirstSolution('425 W 23rd St, New York, NY 10011', [
     { housenumber: '425' }, { street: 'W 23rd St' },
     { locality: 'New York' }, { region: 'NY' }, { postcode: '10011' }
   ])
 
-  assertFirstMatch('1035 Comanchee Trl, West Columbia, South Carolina 29169', [
+  assertFirstSolution('1035 Comanchee Trl, West Columbia, South Carolina 29169', [
     { housenumber: '1035' }, { street: 'Comanchee Trl' },
     { locality: 'West Columbia' }, { region: 'South Carolina' },
     { postcode: '29169' }
   ])
 
-  assertFirstMatch('Texas 76013', [{ region: 'Texas' }, { postcode: '76013' }])
+  assertFirstSolution('Texas 76013', [{ region: 'Texas' }, { postcode: '76013' }])
 
-  assertFirstMatch('Dallas', [{ locality: 'Dallas' }])
+  assertFirstSolution('Dallas', [{ locality: 'Dallas' }])
 
-  assertFirstMatch('California', [{ region: 'California' }])
+  assertFirstSolution('California', [{ region: 'California' }])
 
-  assertFirstMatch('New York', [{ locality: 'New York' }])
+  assertFirstSolution('New York', [{ locality: 'New York' }])
 
-  assertFirstMatch('New York, NY', [{ locality: 'New York' }, { region: 'NY' }])
+  assertFirstSolution('New York, NY', [{ locality: 'New York' }, { region: 'NY' }])
 
-  assertFirstMatch('New York, New York', [
+  assertFirstSolution('New York, New York', [
     { locality: 'New York' }, { region: 'New York' }
   ])
 
-  // assertFirstMatch('northern mariana islands', [])
+  // assertFirstSolution('northern mariana islands', [])
 
-  assertFirstMatch('Santa Monica, California 90407', [
+  assertFirstSolution('Santa Monica, California 90407', [
     { locality: 'Santa Monica' }, { region: 'California' }, { postcode: '90407' }
   ])
 
-  assertFirstMatch('Grand canyon 86023', [
+  assertFirstSolution('Grand canyon 86023', [
     { locality: 'Grand canyon' }, { postcode: '86023' }
   ])
 
-  assertFirstMatch('CT, 06410', [{ region: 'CT' }, { postcode: '06410' }])
+  assertFirstSolution('CT, 06410', [{ region: 'CT' }, { postcode: '06410' }])
 
-  assertFirstMatch('BOOM', [{ locality: 'BOOM' }])
+  assertFirstSolution('BOOM', [{ locality: 'BOOM' }])
 
-  assertFirstMatch('Niagara Falls 76B09', [
+  assertFirstSolution('Niagara Falls 76B09', [
     { locality: 'Niagara Falls' }
   ])
 
-  // assertFirstMatch('123 Broadway, New York, NY 10010', [
+  // assertFirstSolution('123 Broadway, New York, NY 10010', [
   //   { street: '123 Broadway' }, { locality: 'New York' }, { region: 'NY' }, { postcode: '10010' }
   // ])
 
-  assertFirstMatch('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', [
+  assertFirstSolution('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', [
     { place: 'Mt Tabor Park' },
     { housenumber: '6220' }, { street: 'SE Salmon St' },
     { locality: 'Portland' }, { region: 'OR' },
     { postcode: '97215' }, { country: 'USA' }
   ])
 
-  // assertFirstMatch('Mt Tabor Park', [])
+  // assertFirstSolution('Mt Tabor Park', [])
 
-  assertFirstMatch('Mt', [{ region: 'Mt' }])
+  assertFirstSolution('Mt', [{ region: 'Mt' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/addressit.usa.test.js
+++ b/test/addressit.usa.test.js
@@ -2,101 +2,101 @@
 // https://github.com/DamonOehlman/addressit/tree/master/test
 
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('123 Main St, New York, NY 10010', [
+  assertFirstParseMatches('123 Main St, New York, NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assert('123 Main St New York, NY 10010', [
+  assertFirstParseMatches('123 Main St New York, NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assert('123 Main St New York NY 10010', [
+  assertFirstParseMatches('123 Main St New York NY 10010', [
     { housenumber: '123' }, { street: 'Main St' },
     { locality: 'New York' }, { region: 'NY' },
     { postcode: '10010' }
   ])
 
-  assert('123 E 21st st, Brooklyn NY 11020', [
+  assertFirstParseMatches('123 E 21st st, Brooklyn NY 11020', [
     { housenumber: '123' }, { street: 'E 21st st' },
     { locality: 'Brooklyn' }, { region: 'NY' },
     { postcode: '11020' }
   ])
 
-  assert('754 Pharr Rd, Atlanta, Georgia 31035', [
+  assertFirstParseMatches('754 Pharr Rd, Atlanta, Georgia 31035', [
     { housenumber: '754' }, { street: 'Pharr Rd' },
     { locality: 'Atlanta' }, { region: 'Georgia' },
     { postcode: '31035' }
   ])
 
-  assert('601 21st Ave N, Myrtle Beach, South Carolina 29577', [
+  assertFirstParseMatches('601 21st Ave N, Myrtle Beach, South Carolina 29577', [
     { housenumber: '601' }, { street: '21st Ave N' },
     { locality: 'Myrtle Beach' }, { region: 'South Carolina' },
     { postcode: '29577' }
   ])
 
-  assert('425 W 23rd St, New York, NY 10011', [
+  assertFirstParseMatches('425 W 23rd St, New York, NY 10011', [
     { housenumber: '425' }, { street: 'W 23rd St' },
     { locality: 'New York' }, { region: 'NY' }, { postcode: '10011' }
   ])
 
-  assert('1035 Comanchee Trl, West Columbia, South Carolina 29169', [
+  assertFirstParseMatches('1035 Comanchee Trl, West Columbia, South Carolina 29169', [
     { housenumber: '1035' }, { street: 'Comanchee Trl' },
     { locality: 'West Columbia' }, { region: 'South Carolina' },
     { postcode: '29169' }
   ])
 
-  assert('Texas 76013', [{ region: 'Texas' }, { postcode: '76013' }])
+  assertFirstParseMatches('Texas 76013', [{ region: 'Texas' }, { postcode: '76013' }])
 
-  assert('Dallas', [{ locality: 'Dallas' }])
+  assertFirstParseMatches('Dallas', [{ locality: 'Dallas' }])
 
-  assert('California', [{ region: 'California' }])
+  assertFirstParseMatches('California', [{ region: 'California' }])
 
-  assert('New York', [{ locality: 'New York' }])
+  assertFirstParseMatches('New York', [{ locality: 'New York' }])
 
-  assert('New York, NY', [{ locality: 'New York' }, { region: 'NY' }])
+  assertFirstParseMatches('New York, NY', [{ locality: 'New York' }, { region: 'NY' }])
 
-  assert('New York, New York', [
+  assertFirstParseMatches('New York, New York', [
     { locality: 'New York' }, { region: 'New York' }
   ])
 
-  // assert('northern mariana islands', [])
+  // assertFirstParseMatches('northern mariana islands', [])
 
-  assert('Santa Monica, California 90407', [
+  assertFirstParseMatches('Santa Monica, California 90407', [
     { locality: 'Santa Monica' }, { region: 'California' }, { postcode: '90407' }
   ])
 
-  assert('Grand canyon 86023', [
+  assertFirstParseMatches('Grand canyon 86023', [
     { locality: 'Grand canyon' }, { postcode: '86023' }
   ])
 
-  assert('CT, 06410', [{ region: 'CT' }, { postcode: '06410' }])
+  assertFirstParseMatches('CT, 06410', [{ region: 'CT' }, { postcode: '06410' }])
 
-  assert('BOOM', [{ locality: 'BOOM' }])
+  assertFirstParseMatches('BOOM', [{ locality: 'BOOM' }])
 
-  assert('Niagara Falls 76B09', [
+  assertFirstParseMatches('Niagara Falls 76B09', [
     { locality: 'Niagara Falls' }
   ])
 
-  // assert('123 Broadway, New York, NY 10010', [
+  // assertFirstParseMatches('123 Broadway, New York, NY 10010', [
   //   { street: '123 Broadway' }, { locality: 'New York' }, { region: 'NY' }, { postcode: '10010' }
   // ])
 
-  assert('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', [
+  assertFirstParseMatches('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', [
     { place: 'Mt Tabor Park' },
     { housenumber: '6220' }, { street: 'SE Salmon St' },
     { locality: 'Portland' }, { region: 'OR' },
     { postcode: '97215' }, { country: 'USA' }
   ])
 
-  // assert('Mt Tabor Park', [])
+  // assertFirstParseMatches('Mt Tabor Park', [])
 
-  assert('Mt', [{ region: 'Mt' }])
+  assertFirstParseMatches('Mt', [{ region: 'Mt' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/common.js
+++ b/test/common.js
@@ -25,15 +25,15 @@ const assertHelper = (test, parser, firstOnly) => {
   }
 }
 
-const assertFirstParseMatches = (test, parser) => {
+const assertFirstMatch = (test, parser) => {
   return assertHelper(test, parser, true)
 }
 
-const assertAllParsesMatch = (test, parser) => {
+const assertAllMatch = (test, parser) => {
   return assertHelper(test, parser, false)
 }
 
-module.exports.assertFirstParseMatches = assertFirstParseMatches
-module.exports.assertAllParsesMatch = assertAllParsesMatch
+module.exports.assertFirstMatch = assertFirstMatch
+module.exports.assertAllMatch = assertAllMatch
 module.exports.extract = extract
 module.exports.parser = globalParser

--- a/test/common.js
+++ b/test/common.js
@@ -11,7 +11,8 @@ const extract = (tokenizer) => {
   }))
 }
 
-const assertHelper = (test, parser, firstOnly) => {
+// Test if the first solution returned by parser matches the solution in "expected"
+const assertFirstSolution = (test, parser) => {
   let p = (parser || globalParser)
   return (input, expected) => {
     let tokenizer = new Tokenizer(input)
@@ -19,21 +20,29 @@ const assertHelper = (test, parser, firstOnly) => {
     p.solve(tokenizer)
     test(input, (t) => {
       let ext = extract(tokenizer)
-      t.deepEquals(firstOnly === false ? ext : ext[0], expected)
+      t.deepEquals(ext[0], expected)
       t.end()
     })
   }
 }
 
-const assertFirstMatch = (test, parser) => {
-  return assertHelper(test, parser, true)
+// Test if the first N solutions returned by parser matches the solutions
+// in "expected," where N is the length of expected.
+const assertFirstSolutions = (test, parser) => {
+  let p = (parser || globalParser)
+  return (input, expected) => {
+    let tokenizer = new Tokenizer(input)
+    p.classify(tokenizer)
+    p.solve(tokenizer)
+    test(input, (t) => {
+      let ext = extract(tokenizer)
+      t.deepEquals(ext.slice(0, expected.length), expected)
+      t.end()
+    })
+  }
 }
 
-const assertAllMatch = (test, parser) => {
-  return assertHelper(test, parser, false)
-}
-
-module.exports.assertFirstMatch = assertFirstMatch
-module.exports.assertAllMatch = assertAllMatch
+module.exports.assertFirstSolution = assertFirstSolution
+module.exports.assertFirstSolutions = assertFirstSolutions
 module.exports.extract = extract
 module.exports.parser = globalParser

--- a/test/common.js
+++ b/test/common.js
@@ -11,9 +11,9 @@ const extract = (tokenizer) => {
   }))
 }
 
-const assert = (test, parser) => {
+const assertHelper = (test, parser, firstOnly) => {
   let p = (parser || globalParser)
-  return (input, expected, firstOnly) => {
+  return (input, expected) => {
     let tokenizer = new Tokenizer(input)
     p.classify(tokenizer)
     p.solve(tokenizer)
@@ -25,6 +25,15 @@ const assert = (test, parser) => {
   }
 }
 
-module.exports.assert = assert
+const assertFirstParseMatches = (test, parser) => {
+  return assertHelper(test, parser, true)
+}
+
+const assertAllParsesMatch = (test, parser) => {
+  return assertHelper(test, parser, false)
+}
+
+module.exports.assertFirstParseMatches = assertFirstParseMatches
+module.exports.assertAllParsesMatch = assertAllParsesMatch
 module.exports.extract = extract
 module.exports.parser = globalParser

--- a/test/compound_street.test.js
+++ b/test/compound_street.test.js
@@ -1,15 +1,15 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
   // street simple
-  assertFirstParseMatches('Foostraße', [{ street: 'Foostraße' }])
+  assertFirstMatch('Foostraße', [{ street: 'Foostraße' }])
 
   // should not attach a second suffix
-  assertFirstParseMatches('Foostraße Rd', [{ street: 'Foostraße' }])
-  assertFirstParseMatches('foo st and', [{ street: 'foo st' }])
+  assertFirstMatch('Foostraße Rd', [{ street: 'Foostraße' }])
+  assertFirstMatch('foo st and', [{ street: 'foo st' }])
 
   // address simple
-  assertFirstParseMatches('Foostraße 1', [
+  assertFirstMatch('Foostraße 1', [
     { street: 'Foostraße' }, { housenumber: '1' }
   ])
 }

--- a/test/compound_street.test.js
+++ b/test/compound_street.test.js
@@ -1,15 +1,15 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
   // street simple
-  assertFirstMatch('Foostraße', [{ street: 'Foostraße' }])
+  assertFirstSolution('Foostraße', [{ street: 'Foostraße' }])
 
   // should not attach a second suffix
-  assertFirstMatch('Foostraße Rd', [{ street: 'Foostraße' }])
-  assertFirstMatch('foo st and', [{ street: 'foo st' }])
+  assertFirstSolution('Foostraße Rd', [{ street: 'Foostraße' }])
+  assertFirstSolution('foo st and', [{ street: 'foo st' }])
 
   // address simple
-  assertFirstMatch('Foostraße 1', [
+  assertFirstSolution('Foostraße 1', [
     { street: 'Foostraße' }, { housenumber: '1' }
   ])
 }

--- a/test/compound_street.test.js
+++ b/test/compound_street.test.js
@@ -1,15 +1,15 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
   // street simple
-  assert('Foostraße', [{ street: 'Foostraße' }])
+  assertFirstParseMatches('Foostraße', [{ street: 'Foostraße' }])
 
   // should not attach a second suffix
-  assert('Foostraße Rd', [{ street: 'Foostraße' }])
-  assert('foo st and', [{ street: 'foo st' }])
+  assertFirstParseMatches('Foostraße Rd', [{ street: 'Foostraße' }])
+  assertFirstParseMatches('foo st and', [{ street: 'foo st' }])
 
   // address simple
-  assert('Foostraße 1', [
+  assertFirstParseMatches('Foostraße 1', [
     { street: 'Foostraße' }, { housenumber: '1' }
   ])
 }

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -1,49 +1,50 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertAllParsesMatch = common.assertAllParsesMatch(test)
 
   // street simple
-  assert('main pl', [{ street: 'main pl' }])
+  assertFirstParseMatches('main pl', [{ street: 'main pl' }])
 
   // street directional
-  assert('west main st', [{ street: 'west main st' }])
-  assert('main st west', [{ street: 'main st west' }])
+  assertFirstParseMatches('west main st', [{ street: 'west main st' }])
+  assertFirstParseMatches('main st west', [{ street: 'main st west' }])
 
   // street ordinal
-  assert('10th ave', [{ street: '10th ave' }])
+  assertFirstParseMatches('10th ave', [{ street: '10th ave' }])
 
   // street cardinal
-  assert('10 ave', [{ street: '10 ave' }])
+  assertFirstParseMatches('10 ave', [{ street: '10 ave' }])
 
   // address simple
-  assert('1 main pl', [
+  assertFirstParseMatches('1 main pl', [
     { housenumber: '1' }, { street: 'main pl' }
   ])
 
   // address with ordinal
-  assert('100 10th ave', [
+  assertFirstParseMatches('100 10th ave', [
     { housenumber: '100' }, { street: '10th ave' }
   ])
 
   // address with cardinal
-  assert('100 10 ave', [
+  assertFirstParseMatches('100 10 ave', [
     { housenumber: '100' }, { street: '10 ave' }
   ])
 
   // address with directional
-  assert('1 north main blvd', [
+  assertFirstParseMatches('1 north main blvd', [
     { housenumber: '1' }, { street: 'north main blvd' }
   ])
-  assert('1 main blvd north', [
+  assertFirstParseMatches('1 main blvd north', [
     { housenumber: '1' }, { street: 'main blvd north' }
   ])
 
   // address with directional & ordinal
-  assert('30 west 26th street', [
+  assertFirstParseMatches('30 west 26th street', [
     { housenumber: '30' }, { street: 'west 26th street' }
   ])
 
   // street with directional, ordinal & admin info
-  assert('West 26th Street, New York, NYC, 10010', [
+  assertFirstParseMatches('West 26th Street, New York, NYC, 10010', [
     { street: 'West 26th Street' },
     { locality: 'New York' },
     { postcode: '10010' }
@@ -51,35 +52,35 @@ const testcase = (test, common) => {
 
   // do not classify tokens preceeded by a 'place' as
   // an admin classification
-  assert('Portland Cafe Portland OR', [
+  assertFirstParseMatches('Portland Cafe Portland OR', [
     { place: 'Portland Cafe' },
     { locality: 'Portland' }, { region: 'OR' }
   ])
 
   // trailing directional causes issue with autocomplete
-  assert('1 Foo St N', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assert('1 Foo St S', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assert('1 Foo St E', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assert('1 Foo St W', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstParseMatches('1 Foo St N', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstParseMatches('1 Foo St S', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstParseMatches('1 Foo St E', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstParseMatches('1 Foo St W', [{ housenumber: '1' }, { street: 'Foo St' }])
 
   // ...but we allow two letter directionals
-  assert('1 Foo St NW', [{ housenumber: '1' }, { street: 'Foo St NW' }])
-  assert('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }])
-  assert('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }])
-  assert('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }])
+  assertFirstParseMatches('1 Foo St NW', [{ housenumber: '1' }, { street: 'Foo St NW' }])
+  assertFirstParseMatches('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }])
+  assertFirstParseMatches('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }])
+  assertFirstParseMatches('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }])
 
   // invalid solutions (because the classification pairings dont make sense logically)
-  assert('1 San Francisco', [], false)
-  assert('1 California', [], false)
-  assert('1 USA', [], false)
-  assert('1 San Francisco California', [], false)
-  assert('1 San Francisco USA', [], false)
-  assert('1 San Francisco California USA', [], false)
-  assert('1 California USA', [], false)
-  assert('1 90210', [], false)
+  assertAllParsesMatch('1 San Francisco', [])
+  assertAllParsesMatch('1 California', [])
+  assertAllParsesMatch('1 USA', [])
+  assertAllParsesMatch('1 San Francisco California', [])
+  assertAllParsesMatch('1 San Francisco USA', [])
+  assertAllParsesMatch('1 San Francisco California USA', [])
+  assertAllParsesMatch('1 California USA', [])
+  assertAllParsesMatch('1 90210', [])
 
   // do not parse 'aus' as a locality if it follows a region
-  assert('new south wales aus', [
+  assertFirstParseMatches('new south wales aus', [
     { region: 'new south wales' }, { country: 'aus' }
   ])
 }

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -1,50 +1,50 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
-  let assertAllParsesMatch = common.assertAllParsesMatch(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertAllMatch = common.assertAllMatch(test)
 
   // street simple
-  assertFirstParseMatches('main pl', [{ street: 'main pl' }])
+  assertFirstMatch('main pl', [{ street: 'main pl' }])
 
   // street directional
-  assertFirstParseMatches('west main st', [{ street: 'west main st' }])
-  assertFirstParseMatches('main st west', [{ street: 'main st west' }])
+  assertFirstMatch('west main st', [{ street: 'west main st' }])
+  assertFirstMatch('main st west', [{ street: 'main st west' }])
 
   // street ordinal
-  assertFirstParseMatches('10th ave', [{ street: '10th ave' }])
+  assertFirstMatch('10th ave', [{ street: '10th ave' }])
 
   // street cardinal
-  assertFirstParseMatches('10 ave', [{ street: '10 ave' }])
+  assertFirstMatch('10 ave', [{ street: '10 ave' }])
 
   // address simple
-  assertFirstParseMatches('1 main pl', [
+  assertFirstMatch('1 main pl', [
     { housenumber: '1' }, { street: 'main pl' }
   ])
 
   // address with ordinal
-  assertFirstParseMatches('100 10th ave', [
+  assertFirstMatch('100 10th ave', [
     { housenumber: '100' }, { street: '10th ave' }
   ])
 
   // address with cardinal
-  assertFirstParseMatches('100 10 ave', [
+  assertFirstMatch('100 10 ave', [
     { housenumber: '100' }, { street: '10 ave' }
   ])
 
   // address with directional
-  assertFirstParseMatches('1 north main blvd', [
+  assertFirstMatch('1 north main blvd', [
     { housenumber: '1' }, { street: 'north main blvd' }
   ])
-  assertFirstParseMatches('1 main blvd north', [
+  assertFirstMatch('1 main blvd north', [
     { housenumber: '1' }, { street: 'main blvd north' }
   ])
 
   // address with directional & ordinal
-  assertFirstParseMatches('30 west 26th street', [
+  assertFirstMatch('30 west 26th street', [
     { housenumber: '30' }, { street: 'west 26th street' }
   ])
 
   // street with directional, ordinal & admin info
-  assertFirstParseMatches('West 26th Street, New York, NYC, 10010', [
+  assertFirstMatch('West 26th Street, New York, NYC, 10010', [
     { street: 'West 26th Street' },
     { locality: 'New York' },
     { postcode: '10010' }
@@ -52,35 +52,35 @@ const testcase = (test, common) => {
 
   // do not classify tokens preceeded by a 'place' as
   // an admin classification
-  assertFirstParseMatches('Portland Cafe Portland OR', [
+  assertFirstMatch('Portland Cafe Portland OR', [
     { place: 'Portland Cafe' },
     { locality: 'Portland' }, { region: 'OR' }
   ])
 
   // trailing directional causes issue with autocomplete
-  assertFirstParseMatches('1 Foo St N', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assertFirstParseMatches('1 Foo St S', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assertFirstParseMatches('1 Foo St E', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assertFirstParseMatches('1 Foo St W', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstMatch('1 Foo St N', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstMatch('1 Foo St S', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstMatch('1 Foo St E', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstMatch('1 Foo St W', [{ housenumber: '1' }, { street: 'Foo St' }])
 
   // ...but we allow two letter directionals
-  assertFirstParseMatches('1 Foo St NW', [{ housenumber: '1' }, { street: 'Foo St NW' }])
-  assertFirstParseMatches('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }])
-  assertFirstParseMatches('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }])
-  assertFirstParseMatches('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }])
+  assertFirstMatch('1 Foo St NW', [{ housenumber: '1' }, { street: 'Foo St NW' }])
+  assertFirstMatch('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }])
+  assertFirstMatch('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }])
+  assertFirstMatch('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }])
 
   // invalid solutions (because the classification pairings dont make sense logically)
-  assertAllParsesMatch('1 San Francisco', [])
-  assertAllParsesMatch('1 California', [])
-  assertAllParsesMatch('1 USA', [])
-  assertAllParsesMatch('1 San Francisco California', [])
-  assertAllParsesMatch('1 San Francisco USA', [])
-  assertAllParsesMatch('1 San Francisco California USA', [])
-  assertAllParsesMatch('1 California USA', [])
-  assertAllParsesMatch('1 90210', [])
+  assertAllMatch('1 San Francisco', [])
+  assertAllMatch('1 California', [])
+  assertAllMatch('1 USA', [])
+  assertAllMatch('1 San Francisco California', [])
+  assertAllMatch('1 San Francisco USA', [])
+  assertAllMatch('1 San Francisco California USA', [])
+  assertAllMatch('1 California USA', [])
+  assertAllMatch('1 90210', [])
 
   // do not parse 'aus' as a locality if it follows a region
-  assertFirstParseMatches('new south wales aus', [
+  assertFirstMatch('new south wales aus', [
     { region: 'new south wales' }, { country: 'aus' }
   ])
 }

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -1,50 +1,50 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
-  let assertAllMatch = common.assertAllMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
+  let assertFirstSolutions = common.assertFirstSolutions(test)
 
   // street simple
-  assertFirstMatch('main pl', [{ street: 'main pl' }])
+  assertFirstSolution('main pl', [{ street: 'main pl' }])
 
   // street directional
-  assertFirstMatch('west main st', [{ street: 'west main st' }])
-  assertFirstMatch('main st west', [{ street: 'main st west' }])
+  assertFirstSolution('west main st', [{ street: 'west main st' }])
+  assertFirstSolution('main st west', [{ street: 'main st west' }])
 
   // street ordinal
-  assertFirstMatch('10th ave', [{ street: '10th ave' }])
+  assertFirstSolution('10th ave', [{ street: '10th ave' }])
 
   // street cardinal
-  assertFirstMatch('10 ave', [{ street: '10 ave' }])
+  assertFirstSolution('10 ave', [{ street: '10 ave' }])
 
   // address simple
-  assertFirstMatch('1 main pl', [
+  assertFirstSolution('1 main pl', [
     { housenumber: '1' }, { street: 'main pl' }
   ])
 
   // address with ordinal
-  assertFirstMatch('100 10th ave', [
+  assertFirstSolution('100 10th ave', [
     { housenumber: '100' }, { street: '10th ave' }
   ])
 
   // address with cardinal
-  assertFirstMatch('100 10 ave', [
+  assertFirstSolution('100 10 ave', [
     { housenumber: '100' }, { street: '10 ave' }
   ])
 
   // address with directional
-  assertFirstMatch('1 north main blvd', [
+  assertFirstSolution('1 north main blvd', [
     { housenumber: '1' }, { street: 'north main blvd' }
   ])
-  assertFirstMatch('1 main blvd north', [
+  assertFirstSolution('1 main blvd north', [
     { housenumber: '1' }, { street: 'main blvd north' }
   ])
 
   // address with directional & ordinal
-  assertFirstMatch('30 west 26th street', [
+  assertFirstSolution('30 west 26th street', [
     { housenumber: '30' }, { street: 'west 26th street' }
   ])
 
   // street with directional, ordinal & admin info
-  assertFirstMatch('West 26th Street, New York, NYC, 10010', [
+  assertFirstSolution('West 26th Street, New York, NYC, 10010', [
     { street: 'West 26th Street' },
     { locality: 'New York' },
     { postcode: '10010' }
@@ -52,35 +52,35 @@ const testcase = (test, common) => {
 
   // do not classify tokens preceeded by a 'place' as
   // an admin classification
-  assertFirstMatch('Portland Cafe Portland OR', [
+  assertFirstSolution('Portland Cafe Portland OR', [
     { place: 'Portland Cafe' },
     { locality: 'Portland' }, { region: 'OR' }
   ])
 
   // trailing directional causes issue with autocomplete
-  assertFirstMatch('1 Foo St N', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assertFirstMatch('1 Foo St S', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assertFirstMatch('1 Foo St E', [{ housenumber: '1' }, { street: 'Foo St' }])
-  assertFirstMatch('1 Foo St W', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstSolution('1 Foo St N', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstSolution('1 Foo St S', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstSolution('1 Foo St E', [{ housenumber: '1' }, { street: 'Foo St' }])
+  assertFirstSolution('1 Foo St W', [{ housenumber: '1' }, { street: 'Foo St' }])
 
   // ...but we allow two letter directionals
-  assertFirstMatch('1 Foo St NW', [{ housenumber: '1' }, { street: 'Foo St NW' }])
-  assertFirstMatch('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }])
-  assertFirstMatch('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }])
-  assertFirstMatch('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }])
+  assertFirstSolution('1 Foo St NW', [{ housenumber: '1' }, { street: 'Foo St NW' }])
+  assertFirstSolution('1 Foo St NE', [{ housenumber: '1' }, { street: 'Foo St NE' }])
+  assertFirstSolution('1 Foo St SW', [{ housenumber: '1' }, { street: 'Foo St SW' }])
+  assertFirstSolution('1 Foo St SE', [{ housenumber: '1' }, { street: 'Foo St SE' }])
 
   // invalid solutions (because the classification pairings dont make sense logically)
-  assertAllMatch('1 San Francisco', [])
-  assertAllMatch('1 California', [])
-  assertAllMatch('1 USA', [])
-  assertAllMatch('1 San Francisco California', [])
-  assertAllMatch('1 San Francisco USA', [])
-  assertAllMatch('1 San Francisco California USA', [])
-  assertAllMatch('1 California USA', [])
-  assertAllMatch('1 90210', [])
+  assertFirstSolutions('1 San Francisco', [])
+  assertFirstSolutions('1 California', [])
+  assertFirstSolutions('1 USA', [])
+  assertFirstSolutions('1 San Francisco California', [])
+  assertFirstSolutions('1 San Francisco USA', [])
+  assertFirstSolutions('1 San Francisco California USA', [])
+  assertFirstSolutions('1 California USA', [])
+  assertFirstSolutions('1 90210', [])
 
   // do not parse 'aus' as a locality if it follows a region
-  assertFirstMatch('new south wales aus', [
+  assertFirstSolution('new south wales aus', [
     { region: 'new south wales' }, { country: 'aus' }
   ])
 }

--- a/test/intersection.test.js
+++ b/test/intersection.test.js
@@ -1,144 +1,144 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
-  let assertAllParsesMatch = common.assertAllParsesMatch(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertAllMatch = common.assertAllMatch(test)
   // intersection queries
 
   // intersection tokens as a prefix are currently unsupported
-  // assertFirstParseMatches('Corner of Main St & Second Ave', [
+  // assertFirstMatch('Corner of Main St & Second Ave', [
   //   { street: 'Main St' }, { street: 'Second Ave' }
   // ])
-  // assertFirstParseMatches('cnr west st and north ave', [
+  // assertFirstMatch('cnr west st and north ave', [
   //   { street: 'west st' }, { street: 'north ave' }
   // ])
 
-  assertFirstParseMatches('Main St & Second Ave', [
+  assertFirstMatch('Main St & Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assertFirstParseMatches('Main St @ Second Ave', [
+  assertFirstMatch('Main St @ Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assertFirstParseMatches('Main St and Second Ave', [
+  assertFirstMatch('Main St and Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assertFirstParseMatches('12th Avenue and California Street', [
+  assertFirstMatch('12th Avenue and California Street', [
     { street: '12th Avenue' }, { street: 'California Street' }
   ])
 
-  assertFirstParseMatches('15th Avenue and Fulton Street', [
+  assertFirstMatch('15th Avenue and Fulton Street', [
     { street: '15th Avenue' }, { street: 'Fulton Street' }
   ])
 
-  assertFirstParseMatches('17th Avenue & Anza Street', [
+  assertFirstMatch('17th Avenue & Anza Street', [
     { street: '17th Avenue' }, { street: 'Anza Street' }
   ])
 
-  assertFirstParseMatches('Gleimstraße an der ecke von Schönhauser Allee', [
+  assertFirstMatch('Gleimstraße an der ecke von Schönhauser Allee', [
     { street: 'Gleimstraße' }, { street: 'Schönhauser Allee' }
   ])
 
-  assertFirstParseMatches('Gleimstraße und Schönhauserallee', [
+  assertFirstMatch('Gleimstraße und Schönhauserallee', [
     { street: 'Gleimstraße' }, { street: 'Schönhauserallee' }
   ])
 
   // should not consider intersection tokens for street name
-  assertAllParsesMatch('& b', [])
-  assertAllParsesMatch('@ b', [])
-  assertAllParsesMatch('at b', [])
-  assertAllParsesMatch('a &', [])
-  assertAllParsesMatch('a @', [])
-  assertAllParsesMatch('a at', [])
-  assertAllParsesMatch('& street', [])
-  assertAllParsesMatch('@ street', [])
-  assertAllParsesMatch('carrer &', [])
-  assertAllParsesMatch('carrer @', [])
+  assertAllMatch('& b', [])
+  assertAllMatch('@ b', [])
+  assertAllMatch('at b', [])
+  assertAllMatch('a &', [])
+  assertAllMatch('a @', [])
+  assertAllMatch('a at', [])
+  assertAllMatch('& street', [])
+  assertAllMatch('@ street', [])
+  assertAllMatch('carrer &', [])
+  assertAllMatch('carrer @', [])
 
   // should correctly parse street names containing an intersection token
-  assertFirstParseMatches('at street', [{ street: 'at street' }])
-  assertFirstParseMatches('corner street', [{ street: 'corner street' }])
-  assertFirstParseMatches('carrer en', [{ street: 'carrer en' }])
-  assertFirstParseMatches('carrer con', [{ street: 'carrer con' }])
+  assertFirstMatch('at street', [{ street: 'at street' }])
+  assertFirstMatch('corner street', [{ street: 'corner street' }])
+  assertFirstMatch('carrer en', [{ street: 'carrer en' }])
+  assertFirstMatch('carrer con', [{ street: 'carrer con' }])
 
   // no street suffix
-  assertFirstParseMatches('foo & bar', [
+  assertFirstMatch('foo & bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assertFirstParseMatches('foo and bar', [
+  assertFirstMatch('foo and bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assertFirstParseMatches('foo at bar', [
+  assertFirstMatch('foo at bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assertFirstParseMatches('foo @ bar', [
+  assertFirstMatch('foo @ bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
 
   // missing street suffix - alpha
-  assertFirstParseMatches('main st & side ave', [
+  assertFirstMatch('main st & side ave', [
     { street: 'main st' }, { street: 'side ave' }
   ])
-  assertFirstParseMatches('main st & side', [
+  assertFirstMatch('main st & side', [
     { street: 'main st' }, { street: 'side' }
   ])
-  assertFirstParseMatches('main & side ave', [
+  assertFirstMatch('main & side ave', [
     { street: 'main' }, { street: 'side ave' }
   ])
-  assertFirstParseMatches('main & side', [
+  assertFirstMatch('main & side', [
     { street: 'main' }, { street: 'side' }
   ])
 
   // missing street suffix - ordinal
-  assertFirstParseMatches('1st st & 2nd ave', [
+  assertFirstMatch('1st st & 2nd ave', [
     { street: '1st st' }, { street: '2nd ave' }
   ])
-  assertFirstParseMatches('1st st & 2nd', [
+  assertFirstMatch('1st st & 2nd', [
     { street: '1st st' }, { street: '2nd' }
   ])
-  assertFirstParseMatches('1st & 2nd ave', [
+  assertFirstMatch('1st & 2nd ave', [
     { street: '1st' }, { street: '2nd ave' }
   ])
-  assertFirstParseMatches('1st & 2nd', [
+  assertFirstMatch('1st & 2nd', [
     { street: '1st' }, { street: '2nd' }
   ])
 
   // missing street suffix - cardinal
-  assertFirstParseMatches('1 st & 2 ave', [
+  assertFirstMatch('1 st & 2 ave', [
     { street: '1 st' }, { street: '2 ave' }
   ])
-  assertFirstParseMatches('1 st & 2', [
+  assertFirstMatch('1 st & 2', [
     { street: '1 st' }, { street: '2' }
   ])
-  assertFirstParseMatches('1 & 2 ave', [
+  assertFirstMatch('1 & 2 ave', [
     { street: '1' }, { street: '2 ave' }
   ])
-  assertFirstParseMatches('1 & 2', [
+  assertFirstMatch('1 & 2', [
     { street: '1' }, { street: '2' }
   ])
 
-  assertFirstParseMatches('SW 6th & Pine', [
+  assertFirstMatch('SW 6th & Pine', [
     { street: 'SW 6th' }, { street: 'Pine' }
   ])
 
-  assertFirstParseMatches('9th and Lambert', [
+  assertFirstMatch('9th and Lambert', [
     { street: '9th' }, { street: 'Lambert' }
   ])
 
-  assertFirstParseMatches('filbert & 32nd', [
+  assertFirstMatch('filbert & 32nd', [
     { street: 'filbert' }, { street: '32nd' }
   ])
 
   // Should not detect this as an intersection
-  // assertFirstParseMatches('University of Hawaii at Hilo', [
+  // assertFirstMatch('University of Hawaii at Hilo', [
   //   { street: 'SW 6th' }, { street: 'Pine' }
   // ])
-  assertFirstParseMatches('national air and space museum', [
+  assertFirstMatch('national air and space museum', [
     { place: 'national air and space museum' }
   ])
 
   // Trimet syntax
-  // assertFirstParseMatches('9,Lambert', [
+  // assertFirstMatch('9,Lambert', [
   //   { street: '9' }, { street: 'Lambert' }
   // ])
 }

--- a/test/intersection.test.js
+++ b/test/intersection.test.js
@@ -1,144 +1,144 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
-  let assertAllMatch = common.assertAllMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
+  let assertFirstSolutions = common.assertFirstSolutions(test)
   // intersection queries
 
   // intersection tokens as a prefix are currently unsupported
-  // assertFirstMatch('Corner of Main St & Second Ave', [
+  // assertFirstSolution('Corner of Main St & Second Ave', [
   //   { street: 'Main St' }, { street: 'Second Ave' }
   // ])
-  // assertFirstMatch('cnr west st and north ave', [
+  // assertFirstSolution('cnr west st and north ave', [
   //   { street: 'west st' }, { street: 'north ave' }
   // ])
 
-  assertFirstMatch('Main St & Second Ave', [
+  assertFirstSolution('Main St & Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assertFirstMatch('Main St @ Second Ave', [
+  assertFirstSolution('Main St @ Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assertFirstMatch('Main St and Second Ave', [
+  assertFirstSolution('Main St and Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assertFirstMatch('12th Avenue and California Street', [
+  assertFirstSolution('12th Avenue and California Street', [
     { street: '12th Avenue' }, { street: 'California Street' }
   ])
 
-  assertFirstMatch('15th Avenue and Fulton Street', [
+  assertFirstSolution('15th Avenue and Fulton Street', [
     { street: '15th Avenue' }, { street: 'Fulton Street' }
   ])
 
-  assertFirstMatch('17th Avenue & Anza Street', [
+  assertFirstSolution('17th Avenue & Anza Street', [
     { street: '17th Avenue' }, { street: 'Anza Street' }
   ])
 
-  assertFirstMatch('Gleimstraße an der ecke von Schönhauser Allee', [
+  assertFirstSolution('Gleimstraße an der ecke von Schönhauser Allee', [
     { street: 'Gleimstraße' }, { street: 'Schönhauser Allee' }
   ])
 
-  assertFirstMatch('Gleimstraße und Schönhauserallee', [
+  assertFirstSolution('Gleimstraße und Schönhauserallee', [
     { street: 'Gleimstraße' }, { street: 'Schönhauserallee' }
   ])
 
   // should not consider intersection tokens for street name
-  assertAllMatch('& b', [])
-  assertAllMatch('@ b', [])
-  assertAllMatch('at b', [])
-  assertAllMatch('a &', [])
-  assertAllMatch('a @', [])
-  assertAllMatch('a at', [])
-  assertAllMatch('& street', [])
-  assertAllMatch('@ street', [])
-  assertAllMatch('carrer &', [])
-  assertAllMatch('carrer @', [])
+  assertFirstSolutions('& b', [])
+  assertFirstSolutions('@ b', [])
+  assertFirstSolutions('at b', [])
+  assertFirstSolutions('a &', [])
+  assertFirstSolutions('a @', [])
+  assertFirstSolutions('a at', [])
+  assertFirstSolutions('& street', [])
+  assertFirstSolutions('@ street', [])
+  assertFirstSolutions('carrer &', [])
+  assertFirstSolutions('carrer @', [])
 
   // should correctly parse street names containing an intersection token
-  assertFirstMatch('at street', [{ street: 'at street' }])
-  assertFirstMatch('corner street', [{ street: 'corner street' }])
-  assertFirstMatch('carrer en', [{ street: 'carrer en' }])
-  assertFirstMatch('carrer con', [{ street: 'carrer con' }])
+  assertFirstSolution('at street', [{ street: 'at street' }])
+  assertFirstSolution('corner street', [{ street: 'corner street' }])
+  assertFirstSolution('carrer en', [{ street: 'carrer en' }])
+  assertFirstSolution('carrer con', [{ street: 'carrer con' }])
 
   // no street suffix
-  assertFirstMatch('foo & bar', [
+  assertFirstSolution('foo & bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assertFirstMatch('foo and bar', [
+  assertFirstSolution('foo and bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assertFirstMatch('foo at bar', [
+  assertFirstSolution('foo at bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assertFirstMatch('foo @ bar', [
+  assertFirstSolution('foo @ bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
 
   // missing street suffix - alpha
-  assertFirstMatch('main st & side ave', [
+  assertFirstSolution('main st & side ave', [
     { street: 'main st' }, { street: 'side ave' }
   ])
-  assertFirstMatch('main st & side', [
+  assertFirstSolution('main st & side', [
     { street: 'main st' }, { street: 'side' }
   ])
-  assertFirstMatch('main & side ave', [
+  assertFirstSolution('main & side ave', [
     { street: 'main' }, { street: 'side ave' }
   ])
-  assertFirstMatch('main & side', [
+  assertFirstSolution('main & side', [
     { street: 'main' }, { street: 'side' }
   ])
 
   // missing street suffix - ordinal
-  assertFirstMatch('1st st & 2nd ave', [
+  assertFirstSolution('1st st & 2nd ave', [
     { street: '1st st' }, { street: '2nd ave' }
   ])
-  assertFirstMatch('1st st & 2nd', [
+  assertFirstSolution('1st st & 2nd', [
     { street: '1st st' }, { street: '2nd' }
   ])
-  assertFirstMatch('1st & 2nd ave', [
+  assertFirstSolution('1st & 2nd ave', [
     { street: '1st' }, { street: '2nd ave' }
   ])
-  assertFirstMatch('1st & 2nd', [
+  assertFirstSolution('1st & 2nd', [
     { street: '1st' }, { street: '2nd' }
   ])
 
   // missing street suffix - cardinal
-  assertFirstMatch('1 st & 2 ave', [
+  assertFirstSolution('1 st & 2 ave', [
     { street: '1 st' }, { street: '2 ave' }
   ])
-  assertFirstMatch('1 st & 2', [
+  assertFirstSolution('1 st & 2', [
     { street: '1 st' }, { street: '2' }
   ])
-  assertFirstMatch('1 & 2 ave', [
+  assertFirstSolution('1 & 2 ave', [
     { street: '1' }, { street: '2 ave' }
   ])
-  assertFirstMatch('1 & 2', [
+  assertFirstSolution('1 & 2', [
     { street: '1' }, { street: '2' }
   ])
 
-  assertFirstMatch('SW 6th & Pine', [
+  assertFirstSolution('SW 6th & Pine', [
     { street: 'SW 6th' }, { street: 'Pine' }
   ])
 
-  assertFirstMatch('9th and Lambert', [
+  assertFirstSolution('9th and Lambert', [
     { street: '9th' }, { street: 'Lambert' }
   ])
 
-  assertFirstMatch('filbert & 32nd', [
+  assertFirstSolution('filbert & 32nd', [
     { street: 'filbert' }, { street: '32nd' }
   ])
 
   // Should not detect this as an intersection
-  // assertFirstMatch('University of Hawaii at Hilo', [
+  // assertFirstSolution('University of Hawaii at Hilo', [
   //   { street: 'SW 6th' }, { street: 'Pine' }
   // ])
-  assertFirstMatch('national air and space museum', [
+  assertFirstSolution('national air and space museum', [
     { place: 'national air and space museum' }
   ])
 
   // Trimet syntax
-  // assertFirstMatch('9,Lambert', [
+  // assertFirstSolution('9,Lambert', [
   //   { street: '9' }, { street: 'Lambert' }
   // ])
 }

--- a/test/intersection.test.js
+++ b/test/intersection.test.js
@@ -1,144 +1,144 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
-
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertAllParsesMatch = common.assertAllParsesMatch(test)
   // intersection queries
 
   // intersection tokens as a prefix are currently unsupported
-  // assert('Corner of Main St & Second Ave', [
+  // assertFirstParseMatches('Corner of Main St & Second Ave', [
   //   { street: 'Main St' }, { street: 'Second Ave' }
   // ])
-  // assert('cnr west st and north ave', [
+  // assertFirstParseMatches('cnr west st and north ave', [
   //   { street: 'west st' }, { street: 'north ave' }
   // ])
 
-  assert('Main St & Second Ave', [
+  assertFirstParseMatches('Main St & Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assert('Main St @ Second Ave', [
+  assertFirstParseMatches('Main St @ Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assert('Main St and Second Ave', [
+  assertFirstParseMatches('Main St and Second Ave', [
     { street: 'Main St' }, { street: 'Second Ave' }
   ])
 
-  assert('12th Avenue and California Street', [
+  assertFirstParseMatches('12th Avenue and California Street', [
     { street: '12th Avenue' }, { street: 'California Street' }
   ])
 
-  assert('15th Avenue and Fulton Street', [
+  assertFirstParseMatches('15th Avenue and Fulton Street', [
     { street: '15th Avenue' }, { street: 'Fulton Street' }
   ])
 
-  assert('17th Avenue & Anza Street', [
+  assertFirstParseMatches('17th Avenue & Anza Street', [
     { street: '17th Avenue' }, { street: 'Anza Street' }
   ])
 
-  assert('Gleimstraße an der ecke von Schönhauser Allee', [
+  assertFirstParseMatches('Gleimstraße an der ecke von Schönhauser Allee', [
     { street: 'Gleimstraße' }, { street: 'Schönhauser Allee' }
   ])
 
-  assert('Gleimstraße und Schönhauserallee', [
+  assertFirstParseMatches('Gleimstraße und Schönhauserallee', [
     { street: 'Gleimstraße' }, { street: 'Schönhauserallee' }
   ])
 
   // should not consider intersection tokens for street name
-  assert('& b', [], false)
-  assert('@ b', [], false)
-  assert('at b', [], false)
-  assert('a &', [], false)
-  assert('a @', [], false)
-  assert('a at', [], false)
-  assert('& street', [], false)
-  assert('@ street', [], false)
-  assert('carrer &', [], false)
-  assert('carrer @', [], false)
+  assertAllParsesMatch('& b', [])
+  assertAllParsesMatch('@ b', [])
+  assertAllParsesMatch('at b', [])
+  assertAllParsesMatch('a &', [])
+  assertAllParsesMatch('a @', [])
+  assertAllParsesMatch('a at', [])
+  assertAllParsesMatch('& street', [])
+  assertAllParsesMatch('@ street', [])
+  assertAllParsesMatch('carrer &', [])
+  assertAllParsesMatch('carrer @', [])
 
   // should correctly parse street names containing an intersection token
-  assert('at street', [{ street: 'at street' }])
-  assert('corner street', [{ street: 'corner street' }])
-  assert('carrer en', [{ street: 'carrer en' }])
-  assert('carrer con', [{ street: 'carrer con' }])
+  assertFirstParseMatches('at street', [{ street: 'at street' }])
+  assertFirstParseMatches('corner street', [{ street: 'corner street' }])
+  assertFirstParseMatches('carrer en', [{ street: 'carrer en' }])
+  assertFirstParseMatches('carrer con', [{ street: 'carrer con' }])
 
   // no street suffix
-  assert('foo & bar', [
+  assertFirstParseMatches('foo & bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assert('foo and bar', [
+  assertFirstParseMatches('foo and bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assert('foo at bar', [
+  assertFirstParseMatches('foo at bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
-  assert('foo @ bar', [
+  assertFirstParseMatches('foo @ bar', [
     { street: 'foo' }, { street: 'bar' }
   ])
 
   // missing street suffix - alpha
-  assert('main st & side ave', [
+  assertFirstParseMatches('main st & side ave', [
     { street: 'main st' }, { street: 'side ave' }
   ])
-  assert('main st & side', [
+  assertFirstParseMatches('main st & side', [
     { street: 'main st' }, { street: 'side' }
   ])
-  assert('main & side ave', [
+  assertFirstParseMatches('main & side ave', [
     { street: 'main' }, { street: 'side ave' }
   ])
-  assert('main & side', [
+  assertFirstParseMatches('main & side', [
     { street: 'main' }, { street: 'side' }
   ])
 
   // missing street suffix - ordinal
-  assert('1st st & 2nd ave', [
+  assertFirstParseMatches('1st st & 2nd ave', [
     { street: '1st st' }, { street: '2nd ave' }
   ])
-  assert('1st st & 2nd', [
+  assertFirstParseMatches('1st st & 2nd', [
     { street: '1st st' }, { street: '2nd' }
   ])
-  assert('1st & 2nd ave', [
+  assertFirstParseMatches('1st & 2nd ave', [
     { street: '1st' }, { street: '2nd ave' }
   ])
-  assert('1st & 2nd', [
+  assertFirstParseMatches('1st & 2nd', [
     { street: '1st' }, { street: '2nd' }
   ])
 
   // missing street suffix - cardinal
-  assert('1 st & 2 ave', [
+  assertFirstParseMatches('1 st & 2 ave', [
     { street: '1 st' }, { street: '2 ave' }
   ])
-  assert('1 st & 2', [
+  assertFirstParseMatches('1 st & 2', [
     { street: '1 st' }, { street: '2' }
   ])
-  assert('1 & 2 ave', [
+  assertFirstParseMatches('1 & 2 ave', [
     { street: '1' }, { street: '2 ave' }
   ])
-  assert('1 & 2', [
+  assertFirstParseMatches('1 & 2', [
     { street: '1' }, { street: '2' }
   ])
 
-  assert('SW 6th & Pine', [
+  assertFirstParseMatches('SW 6th & Pine', [
     { street: 'SW 6th' }, { street: 'Pine' }
   ])
 
-  assert('9th and Lambert', [
+  assertFirstParseMatches('9th and Lambert', [
     { street: '9th' }, { street: 'Lambert' }
   ])
 
-  assert('filbert & 32nd', [
+  assertFirstParseMatches('filbert & 32nd', [
     { street: 'filbert' }, { street: '32nd' }
   ])
 
   // Should not detect this as an intersection
-  // assert('University of Hawaii at Hilo', [
+  // assertFirstParseMatches('University of Hawaii at Hilo', [
   //   { street: 'SW 6th' }, { street: 'Pine' }
   // ])
-  assert('national air and space museum', [
+  assertFirstParseMatches('national air and space museum', [
     { place: 'national air and space museum' }
   ])
 
   // Trimet syntax
-  // assert('9,Lambert', [
+  // assertFirstParseMatches('9,Lambert', [
   //   { street: '9' }, { street: 'Lambert' }
   // ])
 }

--- a/test/libpostal.test.js
+++ b/test/libpostal.test.js
@@ -2,10 +2,10 @@
 // https://github.com/openvenues/libpostal/issues
 
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
   // https://github.com/openvenues/libpostal/issues/382
-  assert('3360 Grand Ave Oakland 94610-2737 CA', [
+  assertFirstParseMatches('3360 Grand Ave Oakland 94610-2737 CA', [
     { housenumber: '3360' }, { street: 'Grand Ave' },
     { locality: 'Oakland' }, { postcode: '94610-2737' },
     { region: 'CA' }

--- a/test/libpostal.test.js
+++ b/test/libpostal.test.js
@@ -2,10 +2,10 @@
 // https://github.com/openvenues/libpostal/issues
 
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
   // https://github.com/openvenues/libpostal/issues/382
-  assertFirstParseMatches('3360 Grand Ave Oakland 94610-2737 CA', [
+  assertFirstMatch('3360 Grand Ave Oakland 94610-2737 CA', [
     { housenumber: '3360' }, { street: 'Grand Ave' },
     { locality: 'Oakland' }, { postcode: '94610-2737' },
     { region: 'CA' }

--- a/test/libpostal.test.js
+++ b/test/libpostal.test.js
@@ -2,10 +2,10 @@
 // https://github.com/openvenues/libpostal/issues
 
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
   // https://github.com/openvenues/libpostal/issues/382
-  assertFirstMatch('3360 Grand Ave Oakland 94610-2737 CA', [
+  assertFirstSolution('3360 Grand Ave Oakland 94610-2737 CA', [
     { housenumber: '3360' }, { street: 'Grand Ave' },
     { locality: 'Oakland' }, { postcode: '94610-2737' },
     { region: 'CA' }

--- a/test/place.fra.test.js
+++ b/test/place.fra.test.js
@@ -1,59 +1,59 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('École Paul Valéry Montpellier', [
+  assertFirstSolution('École Paul Valéry Montpellier', [
     { place: 'École Paul Valéry' }, { locality: 'Montpellier' }
   ])
 
-  assertFirstMatch('Université de Montpellier', [
+  assertFirstSolution('Université de Montpellier', [
     { place: 'Université de Montpellier' }
   ])
 
-  assertFirstMatch('École Jules Vernes Villetaneuse', [
+  assertFirstSolution('École Jules Vernes Villetaneuse', [
     { place: 'École Jules Vernes' }, { locality: 'Villetaneuse' }
   ])
 
-  assertFirstMatch('ZAC de la Tuilerie, Villars-les-Dombes, France', [
+  assertFirstSolution('ZAC de la Tuilerie, Villars-les-Dombes, France', [
     { place: 'ZAC de la Tuilerie' }, { locality: 'Villars-les-Dombes' }, { country: 'France' }
   ])
 
-  assertFirstMatch('Bibliothèque François Mitterrand Paris', [
+  assertFirstSolution('Bibliothèque François Mitterrand Paris', [
     { place: 'Bibliothèque François Mitterrand' }, { locality: 'Paris' }
   ])
 
-  assertFirstMatch('ZI les grasses Péronnas', [
+  assertFirstSolution('ZI les grasses Péronnas', [
     { place: 'ZI les grasses' }, { locality: 'Péronnas' }
   ])
 
-  assertFirstMatch('ZAC du Pré Polliat', [
+  assertFirstSolution('ZAC du Pré Polliat', [
     { place: 'ZAC du Pré' }, { locality: 'Polliat' }
   ])
 
-  assertFirstMatch('ZAC sous la Combe Lavancia-Epercy', [
+  assertFirstSolution('ZAC sous la Combe Lavancia-Epercy', [
     { place: 'ZAC sous la Combe' }, { locality: 'Lavancia-Epercy' }
   ])
 
-  assertFirstMatch('ZA Entraigues Embrun', [
+  assertFirstSolution('ZA Entraigues Embrun', [
     { place: 'ZA Entraigues' }, { locality: 'Embrun' }
   ])
 
   // This should be street in French, but it's ok
-  assertFirstMatch('Place Sohier Vervins', [
+  assertFirstSolution('Place Sohier Vervins', [
     { street: 'Place Sohier' }, { locality: 'Vervins' }
   ])
 
   // This should be street in French, but it's ok
-  assertFirstMatch('CC des Fours à Chaux Montluçon', [
+  assertFirstSolution('CC des Fours à Chaux Montluçon', [
     { street: 'CC des Fours à Chaux' }, { locality: 'Montluçon' }
   ])
 
   // This should be street in French, but it's ok
-  assertFirstMatch('Parc Des Clots Upie', [
+  assertFirstSolution('Parc Des Clots Upie', [
     { street: 'Parc Des Clots' }, { locality: 'Upie' }
   ])
 
   // Tthe place should be `ZAC du centre Bourg`
-  assertFirstMatch('ZAC du centre Bourg Saint-Sébastien-De-Morsent', [
+  assertFirstSolution('ZAC du centre Bourg Saint-Sébastien-De-Morsent', [
     { place: 'ZAC' }, { street: 'du centre' }, { locality: 'Saint-Sébastien-De-Morsent' }
   ])
 }

--- a/test/place.fra.test.js
+++ b/test/place.fra.test.js
@@ -1,59 +1,59 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('École Paul Valéry Montpellier', [
+  assertFirstMatch('École Paul Valéry Montpellier', [
     { place: 'École Paul Valéry' }, { locality: 'Montpellier' }
   ])
 
-  assertFirstParseMatches('Université de Montpellier', [
+  assertFirstMatch('Université de Montpellier', [
     { place: 'Université de Montpellier' }
   ])
 
-  assertFirstParseMatches('École Jules Vernes Villetaneuse', [
+  assertFirstMatch('École Jules Vernes Villetaneuse', [
     { place: 'École Jules Vernes' }, { locality: 'Villetaneuse' }
   ])
 
-  assertFirstParseMatches('ZAC de la Tuilerie, Villars-les-Dombes, France', [
+  assertFirstMatch('ZAC de la Tuilerie, Villars-les-Dombes, France', [
     { place: 'ZAC de la Tuilerie' }, { locality: 'Villars-les-Dombes' }, { country: 'France' }
   ])
 
-  assertFirstParseMatches('Bibliothèque François Mitterrand Paris', [
+  assertFirstMatch('Bibliothèque François Mitterrand Paris', [
     { place: 'Bibliothèque François Mitterrand' }, { locality: 'Paris' }
   ])
 
-  assertFirstParseMatches('ZI les grasses Péronnas', [
+  assertFirstMatch('ZI les grasses Péronnas', [
     { place: 'ZI les grasses' }, { locality: 'Péronnas' }
   ])
 
-  assertFirstParseMatches('ZAC du Pré Polliat', [
+  assertFirstMatch('ZAC du Pré Polliat', [
     { place: 'ZAC du Pré' }, { locality: 'Polliat' }
   ])
 
-  assertFirstParseMatches('ZAC sous la Combe Lavancia-Epercy', [
+  assertFirstMatch('ZAC sous la Combe Lavancia-Epercy', [
     { place: 'ZAC sous la Combe' }, { locality: 'Lavancia-Epercy' }
   ])
 
-  assertFirstParseMatches('ZA Entraigues Embrun', [
+  assertFirstMatch('ZA Entraigues Embrun', [
     { place: 'ZA Entraigues' }, { locality: 'Embrun' }
   ])
 
   // This should be street in French, but it's ok
-  assertFirstParseMatches('Place Sohier Vervins', [
+  assertFirstMatch('Place Sohier Vervins', [
     { street: 'Place Sohier' }, { locality: 'Vervins' }
   ])
 
   // This should be street in French, but it's ok
-  assertFirstParseMatches('CC des Fours à Chaux Montluçon', [
+  assertFirstMatch('CC des Fours à Chaux Montluçon', [
     { street: 'CC des Fours à Chaux' }, { locality: 'Montluçon' }
   ])
 
   // This should be street in French, but it's ok
-  assertFirstParseMatches('Parc Des Clots Upie', [
+  assertFirstMatch('Parc Des Clots Upie', [
     { street: 'Parc Des Clots' }, { locality: 'Upie' }
   ])
 
   // Tthe place should be `ZAC du centre Bourg`
-  assertFirstParseMatches('ZAC du centre Bourg Saint-Sébastien-De-Morsent', [
+  assertFirstMatch('ZAC du centre Bourg Saint-Sébastien-De-Morsent', [
     { place: 'ZAC' }, { street: 'du centre' }, { locality: 'Saint-Sébastien-De-Morsent' }
   ])
 }

--- a/test/place.fra.test.js
+++ b/test/place.fra.test.js
@@ -1,59 +1,59 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('École Paul Valéry Montpellier', [
+  assertFirstParseMatches('École Paul Valéry Montpellier', [
     { place: 'École Paul Valéry' }, { locality: 'Montpellier' }
   ])
 
-  assert('Université de Montpellier', [
+  assertFirstParseMatches('Université de Montpellier', [
     { place: 'Université de Montpellier' }
   ])
 
-  assert('École Jules Vernes Villetaneuse', [
+  assertFirstParseMatches('École Jules Vernes Villetaneuse', [
     { place: 'École Jules Vernes' }, { locality: 'Villetaneuse' }
   ])
 
-  assert('ZAC de la Tuilerie, Villars-les-Dombes, France', [
+  assertFirstParseMatches('ZAC de la Tuilerie, Villars-les-Dombes, France', [
     { place: 'ZAC de la Tuilerie' }, { locality: 'Villars-les-Dombes' }, { country: 'France' }
   ])
 
-  assert('Bibliothèque François Mitterrand Paris', [
+  assertFirstParseMatches('Bibliothèque François Mitterrand Paris', [
     { place: 'Bibliothèque François Mitterrand' }, { locality: 'Paris' }
   ])
 
-  assert('ZI les grasses Péronnas', [
+  assertFirstParseMatches('ZI les grasses Péronnas', [
     { place: 'ZI les grasses' }, { locality: 'Péronnas' }
   ])
 
-  assert('ZAC du Pré Polliat', [
+  assertFirstParseMatches('ZAC du Pré Polliat', [
     { place: 'ZAC du Pré' }, { locality: 'Polliat' }
   ])
 
-  assert('ZAC sous la Combe Lavancia-Epercy', [
+  assertFirstParseMatches('ZAC sous la Combe Lavancia-Epercy', [
     { place: 'ZAC sous la Combe' }, { locality: 'Lavancia-Epercy' }
   ])
 
-  assert('ZA Entraigues Embrun', [
+  assertFirstParseMatches('ZA Entraigues Embrun', [
     { place: 'ZA Entraigues' }, { locality: 'Embrun' }
   ])
 
   // This should be street in French, but it's ok
-  assert('Place Sohier Vervins', [
+  assertFirstParseMatches('Place Sohier Vervins', [
     { street: 'Place Sohier' }, { locality: 'Vervins' }
   ])
 
   // This should be street in French, but it's ok
-  assert('CC des Fours à Chaux Montluçon', [
+  assertFirstParseMatches('CC des Fours à Chaux Montluçon', [
     { street: 'CC des Fours à Chaux' }, { locality: 'Montluçon' }
   ])
 
   // This should be street in French, but it's ok
-  assert('Parc Des Clots Upie', [
+  assertFirstParseMatches('Parc Des Clots Upie', [
     { street: 'Parc Des Clots' }, { locality: 'Upie' }
   ])
 
   // Tthe place should be `ZAC du centre Bourg`
-  assert('ZAC du centre Bourg Saint-Sébastien-De-Morsent', [
+  assertFirstParseMatches('ZAC du centre Bourg Saint-Sébastien-De-Morsent', [
     { place: 'ZAC' }, { street: 'du centre' }, { locality: 'Saint-Sébastien-De-Morsent' }
   ])
 }

--- a/test/transit.test.js
+++ b/test/transit.test.js
@@ -1,11 +1,11 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Stop 1', [
+  assertFirstParseMatches('Stop 1', [
     { place: 'Stop 1' }
   ])
 
-  assert('Stop 10010', [
+  assertFirstParseMatches('Stop 10010', [
     { place: 'Stop 10010' }
   ])
 }

--- a/test/transit.test.js
+++ b/test/transit.test.js
@@ -1,11 +1,11 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Stop 1', [
+  assertFirstMatch('Stop 1', [
     { place: 'Stop 1' }
   ])
 
-  assertFirstParseMatches('Stop 10010', [
+  assertFirstMatch('Stop 10010', [
     { place: 'Stop 10010' }
   ])
 }

--- a/test/transit.test.js
+++ b/test/transit.test.js
@@ -1,11 +1,11 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Stop 1', [
+  assertFirstSolution('Stop 1', [
     { place: 'Stop 1' }
   ])
 
-  assertFirstMatch('Stop 10010', [
+  assertFirstSolution('Stop 10010', [
     { place: 'Stop 10010' }
   ])
 }

--- a/test/venue.usa.test.js
+++ b/test/venue.usa.test.js
@@ -1,12 +1,12 @@
 const testcase = (test, common) => {
-  let assert = common.assert(test)
+  let assertFirstParseMatches = common.assertFirstParseMatches(test)
 
-  assert('Air & Space Museum Washington DC', [
+  assertFirstParseMatches('Air & Space Museum Washington DC', [
     { place: 'Air & Space Museum' },
     { locality: 'Washington' }, { region: 'DC' }
   ])
 
-  assert('Empire State Building NYC', [
+  assertFirstParseMatches('Empire State Building NYC', [
     { place: 'Empire State Building' },
     { locality: 'NYC' }
   ])

--- a/test/venue.usa.test.js
+++ b/test/venue.usa.test.js
@@ -1,12 +1,12 @@
 const testcase = (test, common) => {
-  let assertFirstParseMatches = common.assertFirstParseMatches(test)
+  let assertFirstMatch = common.assertFirstMatch(test)
 
-  assertFirstParseMatches('Air & Space Museum Washington DC', [
+  assertFirstMatch('Air & Space Museum Washington DC', [
     { place: 'Air & Space Museum' },
     { locality: 'Washington' }, { region: 'DC' }
   ])
 
-  assertFirstParseMatches('Empire State Building NYC', [
+  assertFirstMatch('Empire State Building NYC', [
     { place: 'Empire State Building' },
     { locality: 'NYC' }
   ])

--- a/test/venue.usa.test.js
+++ b/test/venue.usa.test.js
@@ -1,12 +1,12 @@
 const testcase = (test, common) => {
-  let assertFirstMatch = common.assertFirstMatch(test)
+  let assertFirstSolution = common.assertFirstSolution(test)
 
-  assertFirstMatch('Air & Space Museum Washington DC', [
+  assertFirstSolution('Air & Space Museum Washington DC', [
     { place: 'Air & Space Museum' },
     { locality: 'Washington' }, { region: 'DC' }
   ])
 
-  assertFirstMatch('Empire State Building NYC', [
+  assertFirstSolution('Empire State Building NYC', [
     { place: 'Empire State Building' },
     { locality: 'NYC' }
   ])


### PR DESCRIPTION
I was confused when adding tests by the assert function, both because I
am used to "assert" being from a testing library as well as true/false
not being immediately obvious what it did

:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.
