### PR TITLE
More permissive unit patterns

### DIFF
--- a/classifier/UnitClassifier.js
+++ b/classifier/UnitClassifier.js
@@ -1,25 +1,38 @@
 const WordClassifier = require('./super/WordClassifier')
 const UnitClassification = require('../classification/UnitClassification')
 
+const AllNumbersRegExp = /^#?\d+$/
+const SingleLetterRegExp = /^#?[A-Za-z]$/
+const NumbersThenLetterRegExp = /^#?\d+[A-Za-z]$/
+const LetterThenNumbersRegExp = /^#?[A-Za-z]\d+$/
+
+// based on https://stackoverflow.com/questions/9213237/combining-regular-expressions-in-javascript
+function combineRegExps (...args) {
+  var components = []
+
+  args.forEach((arg) => {
+    components = components.concat(arg._components || arg.source)
+  })
+
+  var combined = new RegExp('(?:' + components.join(')|(?:') + ')')
+  return combined
+}
+
+const combinedUnitRegexp = combineRegExps(
+  AllNumbersRegExp,
+  SingleLetterRegExp,
+  NumbersThenLetterRegExp,
+  LetterThenNumbersRegExp
+)
+
 class UnitClassifier extends WordClassifier {
   each (span) {
     const prev = span.graph.findOne('prev')
     const hasPrevUnitToken = prev && prev.classifications.hasOwnProperty('UnitTypeClassification')
 
-    // all numbers or a single letter need to follow a unit type to be a unit
-    // ex: suite a, apt 22
-    if (
-      hasPrevUnitToken && (
-        // all numbers
-        /^#?\d+$/.test(span.body) ||
-        // single letter
-        /^#?[A-Za-z]$/.test(span.body) ||
-        // numbers followed by letter
-        /^#?\d+[A-Za-z]$/.test(span.body) ||
-        // letter followed by numbers
-        /^#?[A-Za-z]\d+$/.test(span.body)
-      )
-    ) {
+    // If the previous token in a unit word, like apt or suite
+    // and this token is something like A2, 3b, 120, A, label it as a unit (number)
+    if (hasPrevUnitToken && combinedUnitRegexp.test(span.body)) {
       span.classify(new UnitClassification(1))
     }
   }

--- a/classifier/UnitClassifier.js
+++ b/classifier/UnitClassifier.js
@@ -5,18 +5,6 @@ class UnitClassifier extends WordClassifier {
   each (span) {
     const prev = span.graph.findOne('prev')
     const hasPrevUnitToken = prev && prev.classifications.hasOwnProperty('UnitTypeClassification')
-    const hasPrevStreetToken = prev && prev.classifications.hasOwnProperty('StreetClassification')
-
-    // number followed by one letter
-    // seems like we can be pretty sure that's a unit number if it follows a unit word or a street
-    // ex: 52 ten eyck st apt 3b
-    // ex: 52 ten eyck st 3b
-    if (
-      (hasPrevStreetToken || hasPrevUnitToken) &&
-      /^#?\d+[A-Za-z]$/.test(span.body)
-    ) {
-      span.classify(new UnitClassification(1))
-    }
 
     // all numbers or a single letter need to follow a unit type to be a unit
     // ex: suite a, apt 22
@@ -25,7 +13,11 @@ class UnitClassifier extends WordClassifier {
         // all numbers
         /^#?\d+$/.test(span.body) ||
         // single letter
-        /^#?[A-Za-z]$/.test(span.body)
+        /^#?[A-Za-z]$/.test(span.body) ||
+        // numbers followed by letter
+        /^#?\d+[A-Za-z]$/.test(span.body) ||
+        // letter followed by numbers
+        /^#?[A-Za-z]\d+$/.test(span.body)
       )
     ) {
       span.classify(new UnitClassification(1))

--- a/classifier/UnitClassifier.test.js
+++ b/classifier/UnitClassifier.test.js
@@ -33,6 +33,11 @@ module.exports.tests.without_unit_type = (test) => {
     t.deepEqual(s.classifications, { })
     t.end()
   })
+  test('letter and number without unit type', (t) => {
+    let s = classify('a2')
+    t.deepEqual(s.classifications, { })
+    t.end()
+  })
   test('single letter without unit type', (t) => {
     let s = classify('a')
     t.deepEqual(s.classifications, { })
@@ -61,8 +66,8 @@ module.exports.tests.with_unit_type = (test) => {
     t.deepEqual(s.classifications, { UnitClassification: new UnitClassification(1.0) })
     t.end()
   })
-  test('number and letter with street type', (t) => {
-    let s = classify('2020a', 'street')
+  test('letter and number with unit type', (t) => {
+    let s = classify('a2', 'unit')
     t.deepEqual(s.classifications, { UnitClassification: new UnitClassification(1.0) })
     t.end()
   })

--- a/classifier/UnitClassifier.test.js
+++ b/classifier/UnitClassifier.test.js
@@ -33,6 +33,16 @@ module.exports.tests.without_unit_type = (test) => {
     t.deepEqual(s.classifications, { })
     t.end()
   })
+  test('single letter without unit type', (t) => {
+    let s = classify('a')
+    t.deepEqual(s.classifications, { })
+    t.end()
+  })
+  test('number with # without unit type', (t) => {
+    let s = classify('#22')
+    t.deepEqual(s.classifications, { })
+    t.end()
+  })
 }
 
 module.exports.tests.with_unit_type = (test) => {
@@ -48,7 +58,22 @@ module.exports.tests.with_unit_type = (test) => {
   })
   test('number and letter with unit type', (t) => {
     let s = classify('2020a', 'unit')
-    t.deepEqual(s.classifications, { })
+    t.deepEqual(s.classifications, { UnitClassification: new UnitClassification(1.0) })
+    t.end()
+  })
+  test('number and letter with street type', (t) => {
+    let s = classify('2020a', 'street')
+    t.deepEqual(s.classifications, { UnitClassification: new UnitClassification(1.0) })
+    t.end()
+  })
+  test('single letter with unit type', (t) => {
+    let s = classify('a', 'unit')
+    t.deepEqual(s.classifications, { UnitClassification: new UnitClassification(1.0) })
+    t.end()
+  })
+  test('number with # with unit type', (t) => {
+    let s = classify('#22', 'unit')
+    t.deepEqual(s.classifications, { UnitClassification: new UnitClassification(1.0) })
     t.end()
   })
 }

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -107,16 +107,22 @@ const testcase = (test, common) => {
     { region: 'NY' }
   ])
 
-  // bummer that this fails - really wants to call "3b" the housenumber instead of 52
-  // assert('52 Ten Eyck St 3b Brooklyn NY', [
-  //   { housenumber: '52' }, { street: 'Ten Eyck St' },
-  //   { unit: '3b' },
-  //   { locality: 'Brooklyn' },
-  //   { region: 'NY' },
-  // ])
+  assert('52 Ten Eyck St 3 Brooklyn NY', [
+    { housenumber: '52' }, { street: 'Ten Eyck St' },
+    { locality: 'Brooklyn' },
+    { region: 'NY' }
+  ])
 
   assert('52 Ten Eyck St 3 Brooklyn NY', [
     { housenumber: '52' }, { street: 'Ten Eyck St' },
+    { locality: 'Brooklyn' },
+    { region: 'NY' }
+  ])
+
+  assert('6 Montague Terrace Apt A2 Brooklyn NY', [
+    { housenumber: '6' }, { street: 'Montague Terrace' },
+    { unit_type: 'Apt' },
+    { unit: 'A2' },
     { locality: 'Brooklyn' },
     { region: 'NY' }
   ])

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -73,6 +73,53 @@ const testcase = (test, common) => {
   assert('1389a IA 42 IA', [{ housenumber: '1389a' }, { street: 'IA 42' }, { region: 'IA' }], true)
 
   assert('1111 MD 760, Lusby, MD, USA', [{ housenumber: '1111' }, { street: 'MD 760' }, { locality: 'Lusby' }, { region: 'MD' }, { country: 'USA' }], true)
+
+  // unit + unit number tests
+  assert('52 Ten Eyck St Apt 3 Brooklyn NY', [
+    { housenumber: '52' }, { street: 'Ten Eyck St' },
+    { unit_type: 'Apt' },
+    { unit: '3' },
+    { locality: 'Brooklyn' },
+    { region: 'NY' }
+  ])
+
+  assert('52 Ten Eyck St Apt 3b Brooklyn NY', [
+    { housenumber: '52' }, { street: 'Ten Eyck St' },
+    { unit_type: 'Apt' },
+    { unit: '3b' },
+    { locality: 'Brooklyn' },
+    { region: 'NY' }
+  ])
+
+  assert('52 Ten Eyck St Apt 3B Brooklyn NY', [
+    { housenumber: '52' }, { street: 'Ten Eyck St' },
+    { unit_type: 'Apt' },
+    { unit: '3B' },
+    { locality: 'Brooklyn' },
+    { region: 'NY' }
+  ])
+
+  assert('52 Ten Eyck St Apt #3b Brooklyn NY', [
+    { housenumber: '52' }, { street: 'Ten Eyck St' },
+    { unit_type: 'Apt' },
+    { unit: '#3b' },
+    { locality: 'Brooklyn' },
+    { region: 'NY' }
+  ])
+
+  // bummer that this fails - really wants to call "3b" the housenumber instead of 52
+  // assert('52 Ten Eyck St 3b Brooklyn NY', [
+  //   { housenumber: '52' }, { street: 'Ten Eyck St' },
+  //   { unit: '3b' },
+  //   { locality: 'Brooklyn' },
+  //   { region: 'NY' },
+  // ])
+
+  assert('52 Ten Eyck St 3 Brooklyn NY', [
+    { housenumber: '52' }, { street: 'Ten Eyck St' },
+    { locality: 'Brooklyn' },
+    { region: 'NY' }
+  ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
I noticed that my apartment number doesn't work in pelias/parser so I tried to make some new patterns that I think would be useful in many places

- single letters after unit-type ie "suite a"
- number+letter units after unit-type ie "apt 3b" (mine! I grew up in an apartment 3G)
- letter+number units after unit-type ie "apt a2" (my last apartment)

I tried to make it such that "52 ten eyck st 3b" would parse as the unit number, since most postcodes wouldn't conflict (netherlands uses a space, UK is AA#, but it would have conflicted with argentina - @####@@@) - but that was moot since the street parser interprets "52 ten eyck st 3b" as street: ten eyck st, housenumber: 3b.