### PR TITLE
support Brazilian postcodes

### DIFF
--- a/classifier/PostcodeClassifier.js
+++ b/classifier/PostcodeClassifier.js
@@ -10,7 +10,7 @@ const dictPath = path.join(__dirname, `../resources/chromium-i18n/ssl-address`)
 // const countryCodes = fs.readdirSync(dictPath)
 //   .filter(p => p.endsWith('.json'))
 //   .map(p => p.split('.')[0])
-const countryCodes = ['us', 'gb', 'fr', 'de', 'es', 'pt', 'au', 'nz', 'kr', 'jp', 'in', 'ru']
+const countryCodes = ['us', 'gb', 'fr', 'de', 'es', 'pt', 'au', 'nz', 'kr', 'jp', 'in', 'ru', 'br']
 
 class PostcodeClassifier extends WordClassifier {
   setup () {

--- a/classifier/PostcodeClassifier.test.js
+++ b/classifier/PostcodeClassifier.test.js
@@ -67,6 +67,11 @@ module.exports.tests.classify = (test) => {
     t.deepEqual(s.classifications, { PostcodeClassification: new PostcodeClassification(1.0) })
     t.end()
   })
+  test('classify: BRA', (t) => {
+    let s = classify('18180-000')
+    t.deepEqual(s.classifications, { PostcodeClassification: new PostcodeClassification(1.0) })
+    t.end()
+  })
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.bra.test.js
+++ b/test/address.bra.test.js
@@ -6,7 +6,7 @@ const testcase = (test, common) => {
     { housenumber: '65' },
     { locality: 'Tapiraí' },
     { region: 'SP' },
-    { postcode: '18180' },
+    { postcode: '18180-000' },
     { country: 'Brazil' }
   ])
 }


### PR DESCRIPTION
I noticed in https://github.com/pelias/parser/pull/99 that the parse was ...almost perfect.

The postcode was being parsed as `18180` instead of `18180-000`.
This PR fixes that by enabling the corresponding regexes.