### PR TITLE
CentralEuropeanStreetNameClassifier: avoid use of section.end

### DIFF
--- a/classifier/CentralEuropeanStreetNameClassifier.js
+++ b/classifier/CentralEuropeanStreetNameClassifier.js
@@ -20,7 +20,9 @@ class CentralEuropeanStreetNameClassifier extends SectionClassifier {
     let next = first.graph.findOne('next')
 
     // section must end with a HouseNumberClassification
-    if (!next || next.end !== section.end || !next.classifications.hasOwnProperty('HouseNumberClassification')) { return }
+    if (!next) { return } // no next span found
+    if (next.graph.findOne('next')) { return } // next span is NOT the final span in the section
+    if (!next.classifications.hasOwnProperty('HouseNumberClassification')) { return }
 
     // other elements cannot contain any public classifications
     if (_.some(first.classifications, (c) => c.public)) { return }

--- a/classifier/CentralEuropeanStreetNameClassifier.test.js
+++ b/classifier/CentralEuropeanStreetNameClassifier.test.js
@@ -23,16 +23,23 @@ module.exports.tests.classify = (test) => {
   baz.graph.add('next', bazHouseNum1)
   bazHouseNum1.graph.add('next', bazHouseNum2)
 
+  // The Qux test case covers when the section has a greater length than
+  // the tokens it contains, such as when it ends with whitespace.
+  let qux = new Span('Qux')
+  let quxHouseNum = new Span('1', 4).classify(new HouseNumberClassification(1.0))
+  qux.graph.add('next', quxHouseNum)
+
   let valid = [
     new Span('Foo 1').setChildren([foo, fooHouseNum]),
     new Span('Bar 2137').setChildren([bar, barHouseNum]),
-    new Span('Baz 152/160').setChildren([baz, bazHouseNum0, bazHouseNum1, bazHouseNum2])
+    new Span('Baz 152/160').setChildren([baz, bazHouseNum0, bazHouseNum1, bazHouseNum2]),
+    new Span('Qux 1 ').setChildren([qux, quxHouseNum])
   ]
 
   valid.forEach(s => {
     test(`classify: ${s.body}`, (t) => {
       // run classifier
-      classifier.each(s, null, 1)
+      classifier.each(s)
 
       // get children
       let children = s.graph.findAll('child')
@@ -40,7 +47,7 @@ module.exports.tests.classify = (test) => {
       // first child should now be classified as a street
       t.deepEqual(_.first(children).classifications, {
         StreetClassification: new StreetClassification(0.5)
-      })
+      }, `'${s.body}'`)
 
       // last child was unchanged
       _.tail(children).forEach(c => {


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/pelias/parser/commit/dd24aaf7dc053be57d45d7b1be8ca31089672b7d#diff-fe38699c6021dd85d3421ba75a0a1fe5

The bug presents itself when the `section.end` is not equal to the `span.end` of the final token.
It sounds unintuitive but the section can contain trailing whitespace whereas the tokens cannot.

This PR replaces the `next.end !== section.end` check with `next.graph.findOne('next')`, which is just a safer way of checking the same thing (that the span is the last one in the section).

Example:
'main 123 ' (note the trailing space) vs. 'main 123'

> I would normally write a boolean check like this as `!!next.graph.findOne('next')` but standardjs didn't like that...
