### PR TITLE
improved USA highway name parsing

### DIFF
--- a/classifier/scheme/street.js
+++ b/classifier/scheme/street.js
@@ -57,7 +57,7 @@ module.exports = [
       },
       {
         is: ['StreetSuffixClassification'],
-        not: ['StreetClassification', 'IntersectionClassification']
+        not: ['StreetClassification', 'IntersectionClassification', 'RoadTypeClassification']
       }
     ]
   },
@@ -284,7 +284,7 @@ module.exports = [
       },
       {
         is: ['NumericClassification'],
-        not: ['PostcodeClassification']
+        not: []
       }
     ]
   },

--- a/resources/pelias/dictionaries/libpostal/en/road_types.txt
+++ b/resources/pelias/dictionaries/libpostal/en/road_types.txt
@@ -11,3 +11,8 @@ state route|sr|stateroute|s.r.|s.r|s r|s.route|s route|st.route|st route|statert
 township highway|th|t.h.|t.h|t h|twp.h|twp h|tshp.h|tshp h|t.hw|t hw|twp.hw|twp hw|tshp.hw|tshp hw|t.hgwy|t hgwy|twp.hgwy|twp hgwy|tshp.hgwy|tshp hgwy|t.hway|t hway|twp.hway|twp hway|tshp.hway|tshp hway|t.hwy|t hwy|twp.hwy|twp hwy|tshp.hwy|tshp hwy|t.hi|t hi|twp.hi|twp hi|tshp.hi|tshp hi
 township road|tr|t.r.|t.r|t r|t rd|t.rd|trd|twpr|twp.r|twp r|twp.rd|twp rd|tshp.r|tshp r|tshp.rd|tshp rd|township rd|tp rd
 township route|tr|t.r.|t.r|t r|t rt|t.rt|trt|t.rte|t rte|twpr|twp.r|twp r|twp.rt|twp rt|twp.rte|twp rte|tshp.r|tshp r|tshp.rt|tshp rt|tshp.rte|tshp rte
+interstate highway|interstate|i|ih|i h
+
+# https://en.wikipedia.org/wiki/Farm-to-market_road
+farm road|fm
+ranch road|rm

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -67,6 +67,13 @@ const testcase = (test, common) => {
   assert('1210a Highway 10 W IA', [{ housenumber: '1210a' }, { street: 'Highway 10 W' }, { region: 'IA' }], true)
   assert('1210a State Highway 10', [{ housenumber: '1210a' }, { street: 'State Highway 10' }], true)
   assert('1389a County Road 42 IA', [{ housenumber: '1389a' }, { street: 'County Road 42' }, { region: 'IA' }], true)
+
+  assert('9600 S Interstate 35 TX', [{ housenumber: '9600' }, { street: 'S Interstate 35' }, { region: 'TX' }], true)
+  assert('9600 Interstate 35 TX', [{ housenumber: '9600' }, { street: 'Interstate 35' }, { region: 'TX' }], true)
+  assert('Interstate 35', [{ street: 'Interstate 35' }], true)
+
+  assert('Fm 3009, TX', [{ street: 'Fm 3009' }, { region: 'TX' }], true)
+
   assert('CA 72', [{ street: 'CA 72' }], true)
   assert('1210a IA 10 W IA', [{ housenumber: '1210a' }, { street: 'IA 10 W' }, { region: 'IA' }], true)
   assert('1210a California 10', [{ housenumber: '1210a' }, { street: 'California 10' }], true)


### PR DESCRIPTION
This PR is motivated by the following failing test cases:

- 9600 S Interstate 35 TX
- Fm 3009, TX

Noteworthy changes:
- Removed `not: PostcodeClassification` from a scheme in `classifier/scheme/street.js` which was preventing highway numbers with more than 3 numerals being classified as streets
- Added `not: RoadTypeClassification` to prevent `10 Interstate 20` from thinking 20 is the house number and 10 the part of the street name
- Added highways synonyms for 'interstate highway' and 'farm-to-market roads'.