### PR TITLE
enforce min given/surname length

### DIFF
--- a/classifier/GivenNameClassifier.js
+++ b/classifier/GivenNameClassifier.js
@@ -8,7 +8,10 @@ const libpostal = require('../resources/libpostal/libpostal')
 class GivenNameClassifier extends PhraseClassifier {
   setup () {
     this.index = {}
-    libpostal.load(this.index, ['all'], 'given_names.txt', { lowercase: true })
+    libpostal.load(this.index, ['all'], 'given_names.txt', {
+      lowercase: true,
+      minlength: 3 // prevent very short names being indexed
+    })
   }
 
   each (span) {

--- a/classifier/SurnameClassifier.js
+++ b/classifier/SurnameClassifier.js
@@ -8,7 +8,10 @@ const libpostal = require('../resources/libpostal/libpostal')
 class SurnameClassifier extends PhraseClassifier {
   setup () {
     this.index = {}
-    libpostal.load(this.index, ['all'], 'surnames.txt', { lowercase: true })
+    libpostal.load(this.index, ['all'], 'surnames.txt', {
+      lowercase: true,
+      minlength: 3 // prevent very short names being indexed
+    })
   }
 
   each (span) {


### PR DESCRIPTION
simple PR to enforce that Given/Surname tokens are at minimum 3 chars.
this is motivated by finding that 'E' was being classified as a surname.

I guess it's possible to have very short names but AFAIK it's fairly uncommon in Europe outside nicknames (which are presumably not used much in a formal addressing context).

Open to changing this to 2 at a later date if the need arises, 1 seems too loose to me.