### PR TITLE
improved parsing of directional prefixes/suffixes

### DIFF
--- a/classifier/scheme/street.js
+++ b/classifier/scheme/street.js
@@ -317,5 +317,20 @@ module.exports = [
         not: ['StreetClassification', 'IntersectionClassification', 'EndTokenSingleCharacterClassification']
       }
     ]
+  },
+  {
+    // West Main Street
+    confidence: 0.88,
+    Class: StreetClassification,
+    scheme: [
+      {
+        is: ['DirectionalClassification'],
+        not: ['StreetClassification', 'IntersectionClassification', 'EndTokenSingleCharacterClassification']
+      },
+      {
+        is: ['StreetClassification'],
+        not: ['DirectionalClassification']
+      }
+    ]
   }
 ]

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -155,6 +155,18 @@ const testcase = (test, common) => {
     { locality: 'Brooklyn' },
     { region: 'NY' }
   ])
+
+  assert('E Cesar Chavez St', [
+    { street: 'E Cesar Chavez St' }
+  ])
+
+  assert('Riverbend Club Dr Se', [
+    { street: 'Riverbend Club Dr Se' }
+  ])
+
+  assert('E William Cannon Dr', [
+    { street: 'E William Cannon Dr' }
+  ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
~~[note] we should probably merge https://github.com/pelias/parser/pull/111 before merging this~~

This work is motivated by the following failing test cases:

- E Cesar Chavez St
- Riverbend Club Dr Se
- E William Cannon Dr

I'm not 100% sure this is the best way to go about it, but there seemed to be a missing classification for `{ordinal} {street}` unless I'm missing something?

~~[note] regarding the comments below I've opened https://github.com/pelias/parser/pull/111 which may be a better place to address that functionality, we can rebase this after that PR is merged and check what remains.~~

~~A little more controversially... I've lowered the confidence of the most common `place` classification.~~

~~We've been finding the high confidence of this classification a bit annoying recently, especially in cases where there exists a place with the same name as a street (such as 'wrigley field').~~

~~The benefit of reducing this confidence value is that in those cases we tend to now score the `street` higher than the `place` which I personally prefer.~~

cc/ @blackmad 