### PR TITLE
add new VenueClassification

### DIFF
--- a/classification/PlaceClassification.js
+++ b/classification/PlaceClassification.js
@@ -3,7 +3,6 @@ const Classification = require('../classification/Classification')
 class PlaceClassification extends Classification {
   constructor (confidence, meta) {
     super(confidence, meta)
-    this.public = true
     this.label = 'place'
   }
 }

--- a/classification/VenueClassification.js
+++ b/classification/VenueClassification.js
@@ -1,0 +1,11 @@
+const Classification = require('./Classification')
+
+class VenueClassification extends Classification {
+  constructor (confidence, meta) {
+    super(confidence, meta)
+    this.public = true
+    this.label = 'venue'
+  }
+}
+
+module.exports = VenueClassification

--- a/classification/VenueClassification.test.js
+++ b/classification/VenueClassification.test.js
@@ -1,12 +1,12 @@
-const Classification = require('./PlaceClassification')
+const Classification = require('./VenueClassification')
 
 module.exports.tests = {}
 
 module.exports.tests.constructor = (test) => {
   test('constructor', (t) => {
     let c = new Classification()
-    t.false(c.public)
-    t.equals(c.label, 'place')
+    t.true(c.public)
+    t.equals(c.label, 'venue')
     t.equals(c.confidence, 1.0)
     t.deepEqual(c.meta, {})
     t.end()
@@ -15,7 +15,7 @@ module.exports.tests.constructor = (test) => {
 
 module.exports.all = (tape, common) => {
   function test (name, testFunction) {
-    return tape(`PlaceClassification: ${name}`, testFunction)
+    return tape(`VenueClassification: ${name}`, testFunction)
   }
 
   for (var testCase in module.exports.tests) {

--- a/classifier/scheme/venue.js
+++ b/classifier/scheme/venue.js
@@ -1,32 +1,32 @@
-const PlaceClassification = require('../../classification/PlaceClassification')
+const VenueClassification = require('../../classification/VenueClassification')
 
 module.exports = [
   {
     // University Hospital
     confidence: 1.0,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       },
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       }
     ]
   },
   {
     // +++ Park
-    confidence: 0.9,
-    Class: PlaceClassification,
+    confidence: 0.7,
+    Class: VenueClassification,
     scheme: [
       {
         is: ['AlphaClassification'],
         not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification']
       },
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       }
     ]
@@ -34,14 +34,14 @@ module.exports = [
   {
     // Mt +++ Park
     confidence: 0.8,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       },
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: []
       }
     ]
@@ -49,7 +49,7 @@ module.exports = [
   {
     // Air & Space Museum
     confidence: 0.8,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
         is: ['AlphaClassification'],
@@ -60,7 +60,7 @@ module.exports = [
         not: ['StreetClassification']
       },
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: []
       }
     ]
@@ -68,14 +68,14 @@ module.exports = [
   {
     // National Air & Space Museum
     confidence: 0.8,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
         is: ['AlphaClassification'],
         not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification']
       },
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: []
       }
     ]
@@ -83,10 +83,10 @@ module.exports = [
   {
     // Stop 10792
     confidence: 0.8,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification', 'IntersectionClassification', 'StopWordClassification']
       },
       {
@@ -98,10 +98,10 @@ module.exports = [
   {
     // University of Somewhere
     confidence: 0.8,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       },
       {
@@ -117,10 +117,10 @@ module.exports = [
   {
     // Ecole Jules Vernes
     confidence: 0.8,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       },
       {
@@ -132,10 +132,10 @@ module.exports = [
   {
     // ZAC du Pré
     confidence: 0.8,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       },
       {
@@ -147,10 +147,10 @@ module.exports = [
   {
     // ZAC de la Tuilerie
     confidence: 0.8,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       },
       {
@@ -166,10 +166,10 @@ module.exports = [
   {
     // ZA Entraigues
     confidence: 0.7,
-    Class: PlaceClassification,
+    Class: VenueClassification,
     scheme: [
       {
-        is: ['PlaceClassification'],
+        is: ['PlaceClassification', 'VenueClassification'],
         not: ['StreetClassification']
       },
       {

--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -77,7 +77,7 @@ class AddressParser extends Parser {
         new CompositeClassifier(require('../classifier/scheme/person')),
         new CompositeClassifier(require('../classifier/scheme/street_name')),
         new CompositeClassifier(require('../classifier/scheme/street')),
-        new CompositeClassifier(require('../classifier/scheme/place')),
+        new CompositeClassifier(require('../classifier/scheme/venue')),
         new CompositeClassifier(require('../classifier/scheme/intersection')),
 
         // additional classifiers which act on unclassified tokens

--- a/solver/Solution.js
+++ b/solver/Solution.js
@@ -63,7 +63,7 @@ class Solution {
     let body = tokenizer.span.body
     let mask = Array(body.length).fill(' ')
     let map = {
-      'place': 'V',
+      'venue': 'V',
       'housenumber': 'N',
       'street': 'S',
       'postcode': 'P',

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -17,7 +17,7 @@ const testcase = (test, common) => {
   ])
 
   assert('Kaschk Bar, Linienstraße 40 10119 Berlin', [
-    { place: 'Kaschk Bar' },
+    { venue: 'Kaschk Bar' },
     { street: 'Linienstraße' }, { housenumber: '40' },
     { postcode: '10119' }, { locality: 'Berlin' }
   ])

--- a/test/address.nzd.test.js
+++ b/test/address.nzd.test.js
@@ -96,6 +96,10 @@ const testcase = (test, common) => {
   assert('4207 Mountain Road', [
     { housenumber: '4207' }, { street: 'Mountain Road' }
   ])
+
+  assert('Mt Victoria Rd, Wellington', [
+    { street: 'Mt Victoria Rd' }, { locality: 'Wellington' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -1,9 +1,11 @@
 const testcase = (test, common) => {
   let assert = common.assert(test)
 
-  assert('wrigley field',
-    [ [ { place: 'wrigley field' } ], [ { street: 'wrigley field' } ], [ { locality: 'field' } ] ],
-    false)
+  assert('wrigley field', [
+    [ { street: 'wrigley field' } ],
+    [ { venue: 'wrigley field' } ],
+    [ { locality: 'field' } ]
+  ], false)
 
   assert('Martin Luther King Jr. Blvd.', [
     { street: 'Martin Luther King Jr. Blvd.' }
@@ -55,12 +57,12 @@ const testcase = (test, common) => {
   assert('N DWIGHT AVE Portland Orego', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }])
   assert('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
 
-  assert('University of Hawaii', [{ place: 'University of Hawaii' }])
+  assert('University of Hawaii', [{ venue: 'University of Hawaii' }])
 
   // Maybe one day this test will pass...
   // see: https://github.com/pelias/parser/pull/49
   // assert('University of Hawaii at Hilo', [
-  //   { place: 'University of Hawaii at Hilo' }
+  //   { venue: 'University of Hawaii at Hilo' }
   // ])
 
   assert('Highway 72', [{ street: 'Highway 72' }], true)
@@ -145,10 +147,9 @@ const testcase = (test, common) => {
     { region: 'NY' }
   ])
 
-  // this isn't a great parse, it probably should
-  // understand 6=housenumber, montague terrace=street
+  // @todo: the #6 should be classified as a unit number
   assert('#6 Montague Terrace Brooklyn NY', [
-    { place: 'Montague Terrace' },
+    { street: 'Montague Terrace' },
     { locality: 'Brooklyn' },
     { region: 'NY' }
   ])

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -58,12 +58,7 @@ const testcase = (test, common) => {
   assert('N DWIGHT AVE Portland Oregon', [{ street: 'N DWIGHT AVE' }, { locality: 'Portland' }, { region: 'Oregon' }])
 
   assert('University of Hawaii', [{ venue: 'University of Hawaii' }])
-
-  // Maybe one day this test will pass...
-  // see: https://github.com/pelias/parser/pull/49
-  // assert('University of Hawaii at Hilo', [
-  //   { venue: 'University of Hawaii at Hilo' }
-  // ])
+  assert('University of Hawaii at Hilo', [{ venue: 'University of Hawaii at Hilo' }])
 
   assert('Highway 72', [{ street: 'Highway 72' }], true)
   assert('1210a Highway 10 W IA', [{ housenumber: '1210a' }, { street: 'Highway 10 W' }, { region: 'IA' }], true)

--- a/test/addressit.usa.test.js
+++ b/test/addressit.usa.test.js
@@ -88,7 +88,7 @@ const testcase = (test, common) => {
   // ])
 
   assert('Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA', [
-    { place: 'Mt Tabor Park' },
+    { venue: 'Mt Tabor Park' },
     { housenumber: '6220' }, { street: 'SE Salmon St' },
     { locality: 'Portland' }, { region: 'OR' },
     { postcode: '97215' }, { country: 'USA' }

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -52,7 +52,7 @@ const testcase = (test, common) => {
   // do not classify tokens preceeded by a 'place' as
   // an admin classification
   assert('Portland Cafe Portland OR', [
-    { place: 'Portland Cafe' },
+    { venue: 'Portland Cafe' },
     { locality: 'Portland' }, { region: 'OR' }
   ])
 

--- a/test/intersection.test.js
+++ b/test/intersection.test.js
@@ -134,7 +134,7 @@ const testcase = (test, common) => {
   //   { street: 'SW 6th' }, { street: 'Pine' }
   // ])
   assert('national air and space museum', [
-    { place: 'national air and space museum' }
+    { venue: 'national air and space museum' }
   ])
 
   // Trimet syntax

--- a/test/place.fra.test.js
+++ b/test/place.fra.test.js
@@ -2,39 +2,39 @@ const testcase = (test, common) => {
   let assert = common.assert(test)
 
   assert('École Paul Valéry Montpellier', [
-    { place: 'École Paul Valéry' }, { locality: 'Montpellier' }
+    { venue: 'École Paul Valéry' }, { locality: 'Montpellier' }
   ])
 
   assert('Université de Montpellier', [
-    { place: 'Université de Montpellier' }
+    { venue: 'Université de Montpellier' }
   ])
 
   assert('École Jules Vernes Villetaneuse', [
-    { place: 'École Jules Vernes' }, { locality: 'Villetaneuse' }
+    { venue: 'École Jules Vernes' }, { locality: 'Villetaneuse' }
   ])
 
   assert('ZAC de la Tuilerie, Villars-les-Dombes, France', [
-    { place: 'ZAC de la Tuilerie' }, { locality: 'Villars-les-Dombes' }, { country: 'France' }
+    { venue: 'ZAC de la Tuilerie' }, { locality: 'Villars-les-Dombes' }, { country: 'France' }
   ])
 
   assert('Bibliothèque François Mitterrand Paris', [
-    { place: 'Bibliothèque François Mitterrand' }, { locality: 'Paris' }
+    { venue: 'Bibliothèque François Mitterrand' }, { locality: 'Paris' }
   ])
 
   assert('ZI les grasses Péronnas', [
-    { place: 'ZI les grasses' }, { locality: 'Péronnas' }
+    { venue: 'ZI les grasses' }, { locality: 'Péronnas' }
   ])
 
   assert('ZAC du Pré Polliat', [
-    { place: 'ZAC du Pré' }, { locality: 'Polliat' }
+    { venue: 'ZAC du Pré' }, { locality: 'Polliat' }
   ])
 
   assert('ZAC sous la Combe Lavancia-Epercy', [
-    { place: 'ZAC sous la Combe' }, { locality: 'Lavancia-Epercy' }
+    { venue: 'ZAC sous la Combe' }, { locality: 'Lavancia-Epercy' }
   ])
 
   assert('ZA Entraigues Embrun', [
-    { place: 'ZA Entraigues' }, { locality: 'Embrun' }
+    { venue: 'ZA Entraigues' }, { locality: 'Embrun' }
   ])
 
   // This should be street in French, but it's ok
@@ -52,9 +52,9 @@ const testcase = (test, common) => {
     { street: 'Parc Des Clots' }, { locality: 'Upie' }
   ])
 
-  // Tthe place should be `ZAC du centre Bourg`
+  // @todo: the place should be `ZAC du centre Bourg`
   assert('ZAC du centre Bourg Saint-Sébastien-De-Morsent', [
-    { place: 'ZAC' }, { street: 'du centre' }, { locality: 'Saint-Sébastien-De-Morsent' }
+    { street: 'ZAC du centre' }, { locality: 'Saint-Sébastien-De-Morsent' }
   ])
 }
 

--- a/test/transit.test.js
+++ b/test/transit.test.js
@@ -2,11 +2,11 @@ const testcase = (test, common) => {
   let assert = common.assert(test)
 
   assert('Stop 1', [
-    { place: 'Stop 1' }
+    { venue: 'Stop 1' }
   ])
 
   assert('Stop 10010', [
-    { place: 'Stop 10010' }
+    { venue: 'Stop 10010' }
   ])
 }
 

--- a/test/venue.usa.test.js
+++ b/test/venue.usa.test.js
@@ -2,12 +2,12 @@ const testcase = (test, common) => {
   let assert = common.assert(test)
 
   assert('Air & Space Museum Washington DC', [
-    { place: 'Air & Space Museum' },
+    { venue: 'Air & Space Museum' },
     { locality: 'Washington' }, { region: 'DC' }
   ])
 
   assert('Empire State Building NYC', [
-    { place: 'Empire State Building' },
+    { venue: 'Empire State Building' },
     { locality: 'NYC' }
   ])
 }


### PR DESCRIPTION
I was thinking about https://github.com/pelias/parser/issues/105 and came to the conclusion that the `PlaceClassification` (ie. `cafe`, `park`, `shopping mall` etc.) should be distinct from (`Cafe Pelias`, `Pelias Park` or `Mall of Pelias`).

So in order to make that distinction I've split the two concepts up into the existing `PlaceClassification` (previously a `public` classification and now `private`) and `VenueClassification` - a public classification which combines a `PlaceClassification` with one or more named tokens to indicate a *specific* cafe, park, mall etc.

I tried to keep it as close to a no-op as possible, thankfully the existing mask symbol for `place` was `V` so I've assigned that to `VenueClassification` now.

I've also included the confidence classification changes mentioned in https://github.com/pelias/parser/pull/110, so this may either partially or completely replace that PR, it felt wrong to do `place` changes in that PR anyway ;)

There were three failing test cases but in all three cases they were covering undesirable solution(s), so I took the liberty to change them, even if the new solution is also still imperfect.

resolves https://github.com/pelias/parser/issues/105