### PR TITLE
generic ability to handle "pha" in addresses

### DIFF
--- a/classifier/UnitTypeUnitClassifier.test.js
+++ b/classifier/UnitTypeUnitClassifier.test.js
@@ -14,11 +14,11 @@ function classify (body) {
 
 module.exports.tests.english_unit_types = (test) => {
   let valid = [
-    'unit16', 'apt23', 'lot75'
+    'unit16', 'apt23', 'lot75', 'pha', 'AptA', 'o22', 'o2'
   ]
 
   let invalid = [
-    'unit', '23', 'Main'
+    'unit', '23', 'Main', 'oa'
   ]
 
   valid.forEach(token => {


### PR DESCRIPTION
This change was motivated by trying to support the unit type "PhA" which is somewhat common in the US (new york at least?) in a generic way.

I fear false positives but it seems mostly okay?

I'm fine if the team decides we don't want to support this. Wanted to put it out in to the world for discussion/appraisal.