### PR TITLE
Add Romanian language to list of languages using street prefix

### DIFF
--- a/classifier/StreetPrefixClassifier.js
+++ b/classifier/StreetPrefixClassifier.js
@@ -7,7 +7,7 @@ const libpostal = require('../resources/libpostal/libpostal')
 
 // prefix languages
 // languages which use a street prefix instead of a suffix
-const prefix = ['fr', 'ca', 'es', 'pt']
+const prefix = ['fr', 'ca', 'es', 'pt', 'ro']
 
 class StreetPrefixClassifier extends WordClassifier {
   setup () {

--- a/classifier/StreetSuffixClassifier.js
+++ b/classifier/StreetSuffixClassifier.js
@@ -7,7 +7,7 @@ const libpostal = require('../resources/libpostal/libpostal')
 
 // prefix languages
 // languages which use a street prefix instead of a suffix
-const prefix = ['fr', 'ca', 'es', 'pt']
+const prefix = ['fr', 'ca', 'es', 'pt', 'ro']
 
 class StreetSuffixClassifier extends WordClassifier {
   setup () {

--- a/test/address.rom.test.js
+++ b/test/address.rom.test.js
@@ -1,0 +1,31 @@
+const testcase = (test, common) => {
+  let assert = common.assert(test)
+
+  assert('Bulevardul Iuliu Maniu, Bucharest', [
+    { street: 'Bulevardul Iuliu Maniu' }, { locality: 'Bucharest' }
+  ])
+
+  assert('Bdul Iuliu Maniu 111 Bucharest', [
+    { street: 'Bdul Iuliu Maniu' }, { housenumber: '111' }, { locality: 'Bucharest' }
+  ])
+
+  assert('Splaiul Independenței 313', [
+    { street: 'Splaiul Independenței' }, { housenumber: '313' }
+  ])
+
+  assert('15 Strada Doctor Carol Davila', [
+    { housenumber: '15' }, { street: 'Strada Doctor Carol Davila' }
+  ])
+
+  assert('Calea Victoriei 54 Bucharest ', [
+    { street: 'Calea Victoriei' }, { housenumber: '54' }, { locality: 'Bucharest' }
+  ])
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`address ROMs: ${name}`, testFunction)
+  }
+
+  testcase(test, common)
+}


### PR DESCRIPTION
In Romania street types are used as prefix https://www.openstreetmap.org/#map=17/44.43396/26.01652