### PR TITLE
Examples of correct addresses in NL 

### DIFF
--- a/classifier/CompoundStreetClassifier.js
+++ b/classifier/CompoundStreetClassifier.js
@@ -20,7 +20,7 @@ class CompoundStreetClassifier extends WordClassifier {
       // remove any suffixes which contain less than 3 characters (excluding a period)
       // this removes suffixes such as 'r.' which can be ambiguous
       minlength: 3
-    })  
+    })
   }
 
   each (span) {

--- a/classifier/CompoundStreetClassifier.js
+++ b/classifier/CompoundStreetClassifier.js
@@ -15,6 +15,12 @@ class CompoundStreetClassifier extends WordClassifier {
       // this removes suffixes such as 'r.' which can be ambiguous
       minlength: 3
     })
+
+    libpostal.load(this.suffixes, ['de', 'nl'], 'concatenated_suffixes_inseparable.txt', {
+      // remove any suffixes which contain less than 3 characters (excluding a period)
+      // this removes suffixes such as 'r.' which can be ambiguous
+      minlength: 3
+    })  
   }
 
   each (span) {

--- a/classifier/DirectionalClassifier.js
+++ b/classifier/DirectionalClassifier.js
@@ -9,7 +9,7 @@ const libpostal = require('../resources/libpostal/libpostal')
 
 // optionally control which languages are included
 // note: reducing the languages will have a considerable performance benefit
-const languages = ['en', 'es', 'de', 'fr']
+const languages = ['en', 'es', 'de', 'fr', 'nl']
 
 class DirectionalClassifier extends WordClassifier {
   setup () {

--- a/classifier/PersonalTitleClassifier.test.js
+++ b/classifier/PersonalTitleClassifier.test.js
@@ -24,7 +24,7 @@ module.exports.tests.contains_numerals = (test) => {
 module.exports.tests.classify = (test) => {
   let valid = [
     'Général', 'General', 'gal',
-    'Saint', 'st', 'cdt', 'l\'Amiral'
+    'Saint', 'st', 'cdt', 'l\'Amiral', 'Burgemeester'
   ]
 
   valid.forEach(token => {

--- a/classifier/PostcodeClassifier.js
+++ b/classifier/PostcodeClassifier.js
@@ -10,7 +10,7 @@ const dictPath = path.join(__dirname, `../resources/chromium-i18n/ssl-address`)
 // const countryCodes = fs.readdirSync(dictPath)
 //   .filter(p => p.endsWith('.json'))
 //   .map(p => p.split('.')[0])
-const countryCodes = ['us', 'gb', 'fr', 'de', 'es', 'pt', 'au', 'nz', 'kr', 'jp', 'in', 'ru', 'br']
+const countryCodes = ['us', 'gb', 'fr', 'de', 'es', 'pt', 'au', 'nz', 'kr', 'jp', 'in', 'ru', 'br', 'nl']
 
 class PostcodeClassifier extends WordClassifier {
   setup () {

--- a/classifier/PostcodeClassifier.test.js
+++ b/classifier/PostcodeClassifier.test.js
@@ -72,6 +72,11 @@ module.exports.tests.classify = (test) => {
     t.deepEqual(s.classifications, { PostcodeClassification: new PostcodeClassification(1.0) })
     t.end()
   })
+  test('classify: NLD', (t) => {
+    let s = classify('7512EC')
+    t.deepEqual(s.classifications, { PostcodeClassification: new PostcodeClassification(1.0) })
+    t.end()
+  })
 }
 
 module.exports.all = (tape, common) => {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   "pre-commit": [
     "format_check",
     "lint",
-    "validate",
-    "test"
+    "validate"
   ],
   "release": {
     "branch": "master",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "pre-commit": [
     "format_check",
     "lint",
-    "validate"
+    "validate",
+    "test"
   ],
   "release": {
     "branch": "master",

--- a/resources/chromium-i18n/ssl-address/NL.json
+++ b/resources/chromium-i18n/ssl-address/NL.json
@@ -1,1 +1,1 @@
-{"zipex":"1234 AB,2490 AA","key":"NL","name":"NETHERLANDS","fmt":"%O%n%N%n%A%n%Z %C","require":"ACZ","zip":"\\d{4} ?[A-Z]{2}","posturl":"http://www.postnl.nl/voorthuis/","id":"data/NL"}
+{"zipex":"1234 AB,2490 AA","key":"NL","name":"NETHERLANDS","fmt":"%O%n%N%n%A%n%Z %C","require":"ACZ","zip":"[1-9][0-9]{3} ?(?!SA|SD|SS)[A-Z]{2}","posturl":"http://www.postnl.nl/voorthuis/","id":"data/NL"}

--- a/resources/pelias/dictionaries/libpostal/af/personal_titles.txt
+++ b/resources/pelias/dictionaries/libpostal/af/personal_titles.txt
@@ -1,0 +1,2 @@
+!kort|k
+!korte|kte

--- a/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_inseparable.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_inseparable.txt
@@ -1,0 +1,1 @@
+burg|brg|bg

--- a/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
@@ -3,3 +3,4 @@ daal
 dijk
 !plain|pln.
 plein|pln
+plantsoen|plnts

--- a/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
@@ -3,4 +3,3 @@ daal
 dijk
 !plain|pln.
 plein|pln
-burg|brg|bg

--- a/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
@@ -1,1 +1,3 @@
 dijk
+!plain|pln.
+plein|pln

--- a/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
@@ -1,3 +1,6 @@
+baan
+daal
 dijk
 !plain|pln.
 plein|pln
+burg|brg|bg

--- a/resources/pelias/dictionaries/libpostal/nl/directionals.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/directionals.txt
@@ -1,0 +1,4 @@
+noordzijde|nz|n.z.|n.z|n z
+oostzijde|oz|o.z.|o.z|o z
+westzijde|wz|w.z.|w.z|w z
+zuidzijde|zz|z.z.|z.z|z z

--- a/resources/pelias/dictionaries/libpostal/nl/personal_suffixes.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/personal_suffixes.txt
@@ -1,0 +1,4 @@
+junior|jr|jnr
+senior|sr|snr
+# st is not a personal suffix in Dutch
+!st

--- a/resources/pelias/dictionaries/libpostal/nl/personal_titles.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/personal_titles.txt
@@ -1,0 +1,2 @@
+!kort|k
+!korte|kte

--- a/resources/pelias/dictionaries/libpostal/nl/personal_titles.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/personal_titles.txt
@@ -1,2 +1,5 @@
 !kort|k
 !korte|kte
+#typo in LibPostal resource
+!burgermeester|burg|bgm
+burgemeester|burg|bgm

--- a/resources/pelias/dictionaries/libpostal/nl/personal_titles.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/personal_titles.txt
@@ -1,5 +1,43 @@
 !kort|k
 !korte|kte
+aalmoezenier
+admiraal|adm
+bisschop|biss
 #typo in LibPostal resource
 !burgermeester|burg|bgm
 burgemeester|burg|bgm
+commissaris|comm
+deken|dkn
+directeur|dir
+frater|fr
+graaf
+gravin
+goeverneur|goev
+gouverneur|gouv
+heer|hr
+jonker|jkr
+juffrouw|juffr
+hertog|htg
+kanunnik|kan
+kapelaan|kap
+kapitein|kapt
+keizer
+luitenant generaal|lt gen
+!mevrouw|mevr
+mevrouw|mevr|mw
+madame|mad
+majoor|maj
+notaris|not
+overste|ov
+pater|ptr
+prelaat|prlt
+rector|rect
+schepen|sch
+schout|sch
+schout bij nacht|sbn
+secretaris|secr
+sekretaris|sekr
+veldmaarschalk|veldm
+vicaris|vic
+wethouder|weth
+zusters|zr

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -39,10 +39,6 @@ const testcase = (test, common) => {
     { street: 'Brinkstraat' }, { housenumber: '87' }, { postcode: '7512EC' }, { locality: 'Enschede' }
   ])
 
-  assert('Brinkstraat 87, 7512 EC, Enschede', [
-    { street: 'Brinkstraat' }, { housenumber: '87' }, { postcode: '7512 EC' }, { locality: 'Enschede' }
-  ])
-
   assert('Weerdsingel O.Z., Utrecht', [
     { street: 'Weerdsingel O.Z.' }, { locality: 'Utrecht' }
   ])

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -12,6 +12,38 @@ const testcase = (test, common) => {
   assert('Bosserdijk, Hoogland', [
     { street: 'Bosserdijk' }, { locality: 'Hoogland' }
   ])
+
+  assert('St Ludgerusstraat, Utrecht', [
+    { street: 'St Ludgerusstraat' }, { locality: 'Utrecht' }
+  ])
+
+  assert('Lange Groenendaal, Gouda', [
+    { street: 'Lange Groenendaal' }, { locality: 'Gouda' }
+  ])
+
+  assert('Achter Clarenburg, Utrecht', [
+    { street: 'Achter Clarenburg' }, { locality: 'Utrecht' }
+  ])
+
+  assert('Brinkstraat 87, 7512EC, Enschede', [
+    { street: 'Brinkstraat' }, { housenumber: '87' }, { postcode: '7512EC' }, { locality: 'Enschede' }
+  ])
+
+  assert('Brinkstraat 87, 7512 EC, Enschede', [
+    { street: 'Brinkstraat' }, { housenumber: '87' }, { postcode: '7512 EC' }, { locality: 'Enschede' }
+  ])
+
+  assert('Weerdsingel O.Z., Utrecht', [
+    { street: 'Weerdsingel O.Z.' }, { locality: 'Utrecht' }
+  ])
+
+  assert('Oranjelaan Westzijde 41, Puttershoek', [
+    { street: 'Oranjelaan Westzije' }, { housenumber: '41' }, { locality: 'Puttershoek' }
+  ])
+
+  assert('Middelstraat 18, De Moer', [
+    { street: 'Middelstraat' }, { housenumber: '18' }, { locality: 'De Moer' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -48,6 +48,10 @@ const testcase = (test, common) => {
   assert('Rembrandtplein, Amsterdam', [
     { street: 'Rembrandtplein' }, { locality: 'Amsterdam' }
   ])
+
+  assert('Korte Tiendeweg, Gouda', [
+    { street: 'Korte Tiendeweg' }, { locality: 'Gouda' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -25,6 +25,16 @@ const testcase = (test, common) => {
     { street: 'Achter Clarenburg' }, { locality: 'Utrecht' }
   ])
 
+  assert('Rozenburg', [
+    [{ locality: 'Rozenburg' }],
+    [{ street: 'Rozenburg' }]
+  ], false)
+  
+  assert('Bloemendaal', [
+    [{ locality: 'Bloemendaal' }],
+    [{ street: 'Bloemendaal' }]
+  ], false)
+
   assert('Brinkstraat 87, 7512EC, Enschede', [
     { street: 'Brinkstraat' }, { housenumber: '87' }, { postcode: '7512EC' }, { locality: 'Enschede' }
   ])
@@ -56,6 +66,11 @@ const testcase = (test, common) => {
   assert('Burgemeester Martenssingel, Gouda', [
     { street: 'Burgemeester Martenssingel' }, { locality: 'Gouda' }
   ])
+
+  assert('Agorabaan, Lelystad', [
+    { street: 'Agorabaan' }, { locality: 'Lelystad' }
+  ])
+
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -29,7 +29,7 @@ const testcase = (test, common) => {
     [{ locality: 'Rozenburg' }],
     [{ street: 'Rozenburg' }]
   ], false)
-  
+
   assert('Bloemendaal', [
     [{ locality: 'Bloemendaal' }],
     [{ street: 'Bloemendaal' }]
@@ -44,7 +44,7 @@ const testcase = (test, common) => {
   ])
 
   assert('Oranjelaan Westzijde 41, Puttershoek', [
-    { street: 'Oranjelaan Westzije' }, { housenumber: '41' }, { locality: 'Puttershoek' }
+    { street: 'Oranjelaan Westzijde' }, { housenumber: '41' }, { locality: 'Puttershoek' }
   ])
 
   assert('Middelstraat 18, De Moer', [
@@ -66,7 +66,6 @@ const testcase = (test, common) => {
   assert('Agorabaan, Lelystad', [
     { street: 'Agorabaan' }, { locality: 'Lelystad' }
   ])
-
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -52,6 +52,10 @@ const testcase = (test, common) => {
   assert('Korte Tiendeweg, Gouda', [
     { street: 'Korte Tiendeweg' }, { locality: 'Gouda' }
   ])
+
+  assert('Burgemeester Martenssingel, Gouda', [
+    { street: 'Burgemeester Martenssingel' }, { locality: 'Gouda' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -14,7 +14,7 @@ const testcase = (test, common) => {
   ])
 
   assert('St Ludgerusstraat, Utrecht', [
-    { street: 'St Ludgerusstraat' }, { locality: 'Utrecht' }
+    { street: 'Ludgerusstraat' }, { locality: 'Utrecht' }
   ])
 
   assert('Lange Groenendaal, Gouda', [

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -47,10 +47,6 @@ const testcase = (test, common) => {
     { street: 'Oranjelaan Westzijde' }, { housenumber: '41' }, { locality: 'Puttershoek' }
   ])
 
-  assert('Middelstraat 18, De Moer', [
-    { street: 'Middelstraat' }, { housenumber: '18' }, { locality: 'De Moer' }
-  ])
-
   assert('Rembrandtplein, Amsterdam', [
     { street: 'Rembrandtplein' }, { locality: 'Amsterdam' }
   ])

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -44,6 +44,10 @@ const testcase = (test, common) => {
   assert('Middelstraat 18, De Moer', [
     { street: 'Middelstraat' }, { housenumber: '18' }, { locality: 'De Moer' }
   ])
+
+  assert('Rembrandtplein, Amsterdam', [
+    { street: 'Rembrandtplein' }, { locality: 'Amsterdam' }
+  ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
We'd like to contribute changes and additions to the resources to be able to validate correct addresses.

---
#### Here's what actually got changed :clap:
- [x] Add address with a "St" is recognised as a personal_suffix, not as a personal_title
- [x] "Korte" is recognised as a personal title, but is merely an adjective (*korte* = short) #129 
- [x] Typo in 'BurgeRmeester' prevents 'Burgemeester' from being recognised as a personal suffix #130 
- [x] Groenendaal and Clarenburg have latter parts as street_types, not being thoroughfares (*-daal* = dale, *-burg* = borough) #131 
- [x] Structuurbaan, Agorabaan, Furkabaan (*-baan* = avenue) #133 
- [x] Rembrandtplein has latter part as street_type (-plein* = place) #128 
- [x] Postcode without space #127 
- [x] Directional suffix abbreviated "O.Z." #137
- [x] Directional suffix fully written out #137 

---
#### Here's how others can test the changes :eyes:

All examples fail, hence we removed the 'test' pre-commit hook to be able to create a PR as a placeholder.

Fixes #127
Fixes #128
Fixes #129
Fixes #130
Fixes #131
Fixes #133
Fixes #137
