### PR TITLE
improved support for streets with no suffix, such as "broadway"

### DIFF
--- a/classification/StreetProperNameClassification.js
+++ b/classification/StreetProperNameClassification.js
@@ -1,0 +1,10 @@
+const Classification = require('./Classification')
+
+class StreetProperNameClassification extends Classification {
+  constructor (confidence, meta) {
+    super(confidence, meta)
+    this.label = 'street_proper_name'
+  }
+}
+
+module.exports = StreetProperNameClassification

--- a/classification/StreetProperNameClassification.test.js
+++ b/classification/StreetProperNameClassification.test.js
@@ -1,0 +1,24 @@
+const Classification = require('./StreetProperNameClassification')
+
+module.exports.tests = {}
+
+module.exports.tests.constructor = (test) => {
+  test('constructor', (t) => {
+    let c = new Classification()
+    t.false(c.public)
+    t.equals(c.label, 'street_proper_name')
+    t.equals(c.confidence, 1.0)
+    t.deepEqual(c.meta, {})
+    t.end()
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`StreetProperNameClassification: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/CompositeClassifier.js
+++ b/classifier/CompositeClassifier.js
@@ -106,8 +106,9 @@ class CompositeClassifier extends SectionClassifier {
         // find phrases which equal the composites
         let superPhrases = []
         composites.forEach(c => {
-          let start = c[0].start
-          let end = c[c.length - 1].end
+          var carr = Array.isArray(c) ? c : [c] // cast to array
+          let start = carr[0].start
+          let end = carr[carr.length - 1].end
           superPhrases = superPhrases.concat(phrases.filter(p => p.start === start && p.end === end))
         })
 

--- a/classifier/StreetProperNameClassifier.js
+++ b/classifier/StreetProperNameClassifier.js
@@ -1,0 +1,29 @@
+const WordClassifier = require('./super/WordClassifier')
+const StreetProperNameClassification = require('../classification/StreetProperNameClassification')
+
+/**
+  Special handling of streets with no suffix
+
+  see: https://github.com/pelias/parser/issues/140
+**/
+
+class StreetProperNameClassifier extends WordClassifier {
+  setup () {
+    this.index = {
+      'broadway': true,
+      'esplanade': true
+    }
+  }
+
+  each (span) {
+    // skip spans which contain numbers
+    if (span.contains.numerals) { return }
+
+    // classify tokens in the index as 'street_proper_name'
+    if (this.index[span.norm] === true) {
+      span.classify(new StreetProperNameClassification(0.7))
+    }
+  }
+}
+
+module.exports = StreetProperNameClassifier

--- a/classifier/StreetProperNameClassifier.test.js
+++ b/classifier/StreetProperNameClassifier.test.js
@@ -1,0 +1,49 @@
+const StreetProperNameClassifier = require('./StreetProperNameClassifier')
+const StreetProperNameClassification = require('../classification/StreetProperNameClassification')
+const Span = require('../tokenization/Span')
+const classifier = new StreetProperNameClassifier()
+
+module.exports.tests = {}
+
+function classify (body) {
+  let s = new Span(body)
+  classifier.each(s, null, 1)
+  return s
+}
+
+module.exports.tests.contains_numerals = (test) => {
+  test('contains numerals: honours contains.numerals boolean', (t) => {
+    let s = new Span('example')
+    s.contains.numerals = true
+    classifier.each(s, null, 1)
+    t.deepEqual(s.classifications, {})
+    t.end()
+  })
+}
+
+module.exports.tests.street_proper_names = (test) => {
+  let valid = [
+    'broadway',
+    'esplanade'
+  ]
+
+  valid.forEach(token => {
+    test(`street_proper_names: ${token}`, (t) => {
+      let s = classify(token)
+      t.deepEqual(s.classifications, {
+        StreetProperNameClassification: new StreetProperNameClassification(0.7)
+      })
+      t.end()
+    })
+  })
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`StreetProperNameClassifier: ${name}`, testFunction)
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common)
+  }
+}

--- a/classifier/scheme/street.js
+++ b/classifier/scheme/street.js
@@ -259,6 +259,32 @@ module.exports = [
     ]
   },
   {
+    // Broadway Market
+    confidence: 0.80,
+    Class: StreetClassification,
+    scheme: [
+      {
+        is: ['StreetProperNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      },
+      {
+        is: ['StreetSuffixClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      }
+    ]
+  },
+  {
+    // Broadway
+    confidence: 0.82,
+    Class: StreetClassification,
+    scheme: [
+      {
+        is: ['StreetProperNameClassification'],
+        not: ['StreetClassification', 'IntersectionClassification']
+      }
+    ]
+  },
+  {
     // +++ Main Street
     confidence: 0.84,
     Class: StreetClassification,

--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -8,6 +8,7 @@ const UnitTypeUnitClassifier = require('../classifier/UnitTypeUnitClassifier')
 const PostcodeClassifier = require('../classifier/PostcodeClassifier')
 const StreetPrefixClassifier = require('../classifier/StreetPrefixClassifier')
 const StreetSuffixClassifier = require('../classifier/StreetSuffixClassifier')
+const StreetProperNameClassifier = require('../classifier/StreetProperNameClassifier')
 const RoadTypeClassifier = require('../classifier/RoadTypeClassifier')
 const ToponymClassifier = require('../classifier/ToponymClassifier')
 const CompoundStreetClassifier = require('../classifier/CompoundStreetClassifier')
@@ -56,6 +57,7 @@ class AddressParser extends Parser {
         new PostcodeClassifier(),
         new StreetPrefixClassifier(),
         new StreetSuffixClassifier(),
+        new StreetProperNameClassifier(),
         new RoadTypeClassifier(),
         new ToponymClassifier(),
         new CompoundStreetClassifier(),

--- a/resources/pelias/dictionaries/libpostal/en/street_types.txt
+++ b/resources/pelias/dictionaries/libpostal/en/street_types.txt
@@ -10,3 +10,7 @@ furlong
 # 1384 Cambridge beltway, Cambridge, MD 21613, USA
 beltway
 
+# https://github.com/pelias/parser/issues/140
+!broadway|bdwy|bway|bwy|brdway
+!esplanade|esp|espl
+market

--- a/resources/pelias/dictionaries/libpostal/fr/street_types.txt
+++ b/resources/pelias/dictionaries/libpostal/fr/street_types.txt
@@ -1,2 +1,5 @@
 cité|cite
 cités|cites
+
+# https://github.com/pelias/parser/pull/141#issuecomment-895230721
+!esplanades|esps

--- a/resources/pelias/dictionaries/whosonfirst/locality/name:eng_x_preferred.txt
+++ b/resources/pelias/dictionaries/whosonfirst/locality/name:eng_x_preferred.txt
@@ -75,3 +75,7 @@ bronx
 !wisconsin
 !wyoming
 
+# https://github.com/pelias/parser/issues/140
+!broadway
+!esplanade
+!market

--- a/resources/pelias/dictionaries/whosonfirst/locality/name:fra_x_preferred.txt
+++ b/resources/pelias/dictionaries/whosonfirst/locality/name:fra_x_preferred.txt
@@ -1,0 +1,2 @@
+# https://github.com/pelias/parser/issues/140
+!broadway

--- a/test/address.deu.test.js
+++ b/test/address.deu.test.js
@@ -27,8 +27,18 @@ const testcase = (test, common) => {
     { locality: 'Munich' }, { country: 'Germany' }
   ])
 
+  assert('Esplanade, Berlin', [
+    { street: 'Esplanade' },
+    { locality: 'Berlin' }
+  ])
+
   assert('Esplanade 17, Berlin', [
     { street: 'Esplanade' }, { housenumber: '17' },
+    { locality: 'Berlin' }
+  ])
+
+  assert('17 Esplanade, Berlin', [
+    { housenumber: '17' }, { street: 'Esplanade' },
     { locality: 'Berlin' }
   ])
 

--- a/test/address.fra.test.js
+++ b/test/address.fra.test.js
@@ -112,6 +112,11 @@ const testcase = (test, common) => {
   assert(`Paris 75000, France`, [
     { locality: 'Paris' }, { postcode: '75000' }, { country: 'France' }
   ])
+
+  // https://github.com/pelias/parser/pull/141#issuecomment-895230721
+  assert(`Esplanade de la Liberté`, [{ street: 'Esplanade de la Liberté' }])
+  assert(`Esplanade du Géneral de Gaulle`, [{ street: 'Esplanade du Géneral de Gaulle' }])
+  assert(`Esplanade Méditerranée`, [{ street: 'Esplanade Méditerranée' }])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.gbr.test.js
+++ b/test/address.gbr.test.js
@@ -4,6 +4,19 @@ const testcase = (test, common) => {
   assert('Rushendon Furlong', [
     { street: 'Rushendon Furlong' }
   ])
+
+  // Valid street name in London
+  assert('Broadway Market, London', [
+    { street: 'Broadway Market' },
+    { locality: 'London' }
+  ])
+
+  // 'The Dove', a pub on Broadway Market
+  assert('24-28 Broadway Market, London', [
+    { housenumber: '24-28' },
+    { street: 'Broadway Market' },
+    { locality: 'London' }
+  ])
 }
 
 module.exports.all = (tape, common) => {

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -249,6 +249,36 @@ const testcase = (test, common) => {
     { locality: 'boston' },
     { region: 'ma' }
   ])
+
+  // https://github.com/pelias/parser/issues/140
+  assert('Broadway, Manhattan', [
+    { street: 'Broadway' },
+    { locality: 'Manhattan' }
+  ])
+  assert('24 Broadway, Manhattan', [
+    { housenumber: '24' }, { street: 'Broadway' },
+    { locality: 'Manhattan' }
+  ])
+  assert('Broadway 24, Manhattan', [
+    { street: 'Broadway' }, { housenumber: '24' },
+    { locality: 'Manhattan' }
+  ])
+  assert('East Broadway, Manhattan', [
+    { street: 'East Broadway' },
+    { locality: 'Manhattan' }
+  ])
+  assert('24 East Broadway, Manhattan', [
+    { housenumber: '24' }, { street: 'East Broadway' },
+    { locality: 'Manhattan' }
+  ])
+  assert('West Broadway, Manhattan', [
+    { street: 'West Broadway' },
+    { locality: 'Manhattan' }
+  ])
+  assert('24 West Broadway, Manhattan', [
+    { housenumber: '24' }, { street: 'West Broadway' },
+    { locality: 'Manhattan' }
+  ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
this PR resolves the issue discussed in https://github.com/pelias/parser/issues/140

it works by:
- modifying the dictionaries as discussed in the issue description
- adding a new classification for street proper names
- updating the `street` composite classifier config to re-classify `street_proper_name+street_suffix` and `street_proper_name` as `street`
- added a bunch of tests and tuned the dictionaries accordingly

no regressions, cc @kochis
resolves https://github.com/pelias/parser/issues/140