### PR TITLE
dictionaries: do not consider "parish" as a venue designation

### DIFF
--- a/resources/pelias/dictionaries/libpostal/en/place_names.txt
+++ b/resources/pelias/dictionaries/libpostal/en/place_names.txt
@@ -4,3 +4,4 @@ stop
 !dist
 building
 field
+!parish

--- a/test/address.usa.test.js
+++ b/test/address.usa.test.js
@@ -279,6 +279,12 @@ const testcase = (test, common) => {
     { housenumber: '24' }, { street: 'West Broadway' },
     { locality: 'Manhattan' }
   ])
+
+  // These solutions aren't perfect but the cases exist to
+  // ensure that 'parish' isnt being interpreted as a venue.
+  // https://github.com/pelias/pelias/issues/912
+  assert('Jefferson Parish', [{ locality: 'Jefferson' }])
+  assert('Mills County', [{ locality: 'Mills' }])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
this PR resolves the issue mentioned in https://github.com/pelias/pelias/issues/912 where the token "Parish" is being interpreted as a venue designation.

closes https://github.com/pelias/pelias/issues/912