### PR TITLE
Add Swedish separable addresses

### DIFF
--- a/classifier/CompoundStreetClassifier.js
+++ b/classifier/CompoundStreetClassifier.js
@@ -10,7 +10,7 @@ class CompoundStreetClassifier extends WordClassifier {
     // load street suffixes
     this.suffixes = {}
 
-    libpostal.load(this.suffixes, ['de', 'nl'], 'concatenated_suffixes_separable.txt', {
+    libpostal.load(this.suffixes, ['de', 'nl', 'sv'], 'concatenated_suffixes_separable.txt', {
       // remove any suffixes which contain less than 3 characters (excluding a period)
       // this removes suffixes such as 'r.' which can be ambiguous
       minlength: 3

--- a/classifier/CompoundStreetClassifier.test.js
+++ b/classifier/CompoundStreetClassifier.test.js
@@ -28,7 +28,8 @@ module.exports.tests.german_compound = (test) => {
     'testallee',
     'testweg',
     'testplatz',
-    'testpl.'
+    'testpl.',
+    'testvägen'
   ]
 
   let invalid = [

--- a/resources/pelias/dictionaries/libpostal/sv/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/sv/concatenated_suffixes_separable.txt
@@ -1,0 +1,1 @@
+vägen|vagen|v.

--- a/test/address.swe.test.js
+++ b/test/address.swe.test.js
@@ -1,0 +1,27 @@
+const testcase = (test, common) => {
+  let assert = common.assert(test)
+
+  assert('Gamla Varmdovagen 6', [
+    { street: 'Gamla Varmdovagen' }, { housenumber: '6' }
+  ])
+
+  assert('Gamla Varmdovägen 6', [
+    { street: 'Gamla Varmdovägen' }, { housenumber: '6' }
+  ])
+
+  assert('Gamla Varmdo vägen 6', [
+    { street: 'Gamla Varmdo vägen' }, { housenumber: '6' }
+  ])
+
+  assert('Ångermannagatan 80, Vällingby', [
+    { street: 'Ångermannagatan' }, { housenumber: '80' } /*, { locality: 'Vällingby' } */
+  ])
+}
+
+module.exports.all = (tape, common) => {
+  function test (name, testFunction) {
+    return tape(`address AUS: ${name}`, testFunction)
+  }
+
+  testcase(test, common)
+}


### PR DESCRIPTION
Add support for Swedish addresses. They work like addresses in Germany.