### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run unit tests
         run: |
           npm install
-          npm run travis
+          npm run ci
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,9 +21,29 @@ jobs:
         run: |
           npm install
           npm run travis
-  build-docker-images:
+  npm-publish:
     needs: unit-tests
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 16.x
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >
+          if [[ -n "$GH_TOKEN" && -n "$NPM_TOKEN" ]]; then
+            curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
+          fi
+  build-docker-images:
+    # run this job if the unit tests passed and the npm-publish job was a success or was skipped
+    # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
+    if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
+    needs: [unit-tests, npm-publish]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -33,21 +53,3 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           curl "https://raw.githubusercontent.com/pelias/ci-tools/master/build-docker-images.sh" | bash -
-  npm-publish:
-    needs: unit-tests
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node.js 12.x
-        uses: actions/setup-node@v2-beta
-        with:
-          node-version: 12.x
-      - name: Run semantic-release
-        env:
-          GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: >
-          if [[ -n "$GH_TOKEN" && -n "$NPM_TOKEN" ]]; then
-            curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
-          fi

--- a/README.md
+++ b/README.md
@@ -218,10 +218,7 @@ $ npm test
 
 ### Continuous Integration
 
-Travis tests every release against all supported Node.js versions.
-
-[![Build Status](https://travis-ci.org/pelias/parser.png?branch=master)](https://travis-ci.org/pelias/parser)
-
+CI tests every release against all supported Node.js versions.
 
 ### Versioning
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format_fix": "./node_modules/standard/bin/cmd.js --fix",
     "server": "node ./server/http.js",
     "test": "./bin/test",
-    "travis": "./bin/test",
+    "ci": "./bin/test",
     "lint": "jshint .",
     "validate": "npm ls"
   },


### PR DESCRIPTION
This copies the Github Actions workflow from the Pelias API project.

It brings in a few notable changes:
- Run all tests against Node.js 12, 14, and 16
- Remove MacOS build jobs (they're 10x the cost, which could hurt anyone running these on private forks)
- Update jobs to run on Ubuntu 20 (Ubuntu 16 is deprecated: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/)
- Run docker build _after_ any NPM publish, so that versioned docker images can be built
- Remove any CircleCI config that exists (we can use Github Actions to build docker images just fine)
- Remove any lingering references to TravisCI