### PR TITLE
apply penalty to postcode solutions in certain patterns

### DIFF
--- a/parser/AddressParser.js
+++ b/parser/AddressParser.js
@@ -36,6 +36,7 @@ const MustNotPreceedFilter = require('../solver/MustNotPreceedFilter')
 const MustNotFollowFilter = require('../solver/MustNotFollowFilter')
 const SubsetFilter = require('../solver/SubsetFilter')
 const HouseNumberPositionPenalty = require('../solver/HouseNumberPositionPenalty')
+const PostcodePositionPenalty = require('../solver/PostcodePositionPenalty')
 
 class AddressParser extends Parser {
   constructor (options) {
@@ -123,6 +124,7 @@ class AddressParser extends Parser {
         new MustNotFollowFilter('LocalityClassification', 'RegionClassification'),
         new MustNotFollowFilter('LocalityClassification', 'CountryClassification'),
         new HouseNumberPositionPenalty(),
+        new PostcodePositionPenalty(),
         new TokenDistanceFilter(),
         new OrphanedUnitTypeDeclassifier(),
         new SubsetFilter()

--- a/solver/PostcodePositionPenalty.js
+++ b/solver/PostcodePositionPenalty.js
@@ -1,0 +1,35 @@
+const BaseSolver = require('./super/BaseSolver')
+const HouseNumberClassification = require('../classification/HouseNumberClassification')
+const PostcodeClassification = require('../classification/PostcodeClassification')
+const StreetClassification = require('../classification/StreetClassification')
+const basePenalty = 0.1
+
+/**
+ * PostcodePositionPenalty applies a penalty to solutions where the postcode
+ * may have recieved a high score but doesn't commonly occur in this pattern.
+ *
+ * eg. rua godinho de faria 1200
+ */
+
+class PostcodePositionPenalty extends BaseSolver {
+  solve (tokenizer) {
+    tokenizer.solution.forEach(s => {
+      // Do nothing if the solution doesn't have a postcode classification
+      const postcode = s.pair.find(p => p.classification.constructor === PostcodeClassification)
+      if (!postcode) { return }
+
+      // Do nothing if the solution has a housenumber classification
+      const housenumber = s.pair.find(p => p.classification.constructor === HouseNumberClassification)
+      if (housenumber) { return }
+
+      // Do nothing for solutions with either none or 2+ street classifications (intersections)
+      const streetCount = s.pair.filter(p => p.classification.constructor === StreetClassification).length
+      if (streetCount === 0 || streetCount >= 2) { return }
+
+      // apply a small penalty
+      s.penalty += basePenalty
+    })
+  }
+}
+
+module.exports = PostcodePositionPenalty

--- a/test/address.prt.test.js
+++ b/test/address.prt.test.js
@@ -28,6 +28,15 @@ const testcase = (test, common) => {
     { street: 'Tv. dos Fiéis de Deus' }, { housenumber: '12C' },
     { region: 'Lisboa' }, { country: 'Portugal' }
   ])
+
+  assert('rua godinho de faria 1200', [
+    { street: 'rua godinho de faria' }, { housenumber: '1200' }
+  ])
+
+  assert('rua godinho de faria 1200 porto', [
+    { street: 'rua godinho de faria' }, { housenumber: '1200' },
+    { locality: 'porto' }
+  ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
proposed solution for https://github.com/pelias/parser/issues/155

this PR applies a penalty to solutions where a `postcode` classification exists but it might be better to score a solution containing a `housenumber` classification higher.

eg. `{street}, {housenumber}` solutions should generally be preferable to `{street}, {postcode}` solutions.

resolves https://github.com/pelias/parser/issues/155