### PR TITLE
performance: add circuit breakers in the ExclusiveCartesianSolver

### DIFF
--- a/solver/ExclusiveCartesianSolver.js
+++ b/solver/ExclusiveCartesianSolver.js
@@ -1,5 +1,7 @@
 const Solution = require('./Solution')
 const HashMapSolver = require('./super/HashMapSolver')
+const MAX_RECURSION = 10
+const MAX_SOLUTIONS = 50000
 
 class ExclusiveCartesianSolver extends HashMapSolver {
   solve (tokenizer) {
@@ -20,10 +22,10 @@ class ExclusiveCartesianSolver extends HashMapSolver {
           copy.pair.push(arg[i].pair[j])
         }
         if (i === max) {
-          if (copy.pair.length) {
+          if (copy.pair.length && r.length < MAX_SOLUTIONS) {
             r.push(copy)
           }
-        } else {
+        } else if (i < MAX_RECURSION) {
           helper(copy, i + 1)
         }
       }

--- a/solver/super/HashMapSolver.js
+++ b/solver/super/HashMapSolver.js
@@ -2,6 +2,7 @@ const BaseSolver = require('./BaseSolver')
 const Span = require('../../tokenization/Span')
 const Solution = require('../Solution')
 const SolutionPair = require('../SolutionPair')
+const MAX_PAIRS_PER_LABEL = 8
 
 class HashMapSolver extends BaseSolver {
   // you should provide this function in your subclass
@@ -27,6 +28,7 @@ class HashMapSolver extends BaseSolver {
               map[classification.label].pair.push(new SolutionPair(new Span(), classification))
             }
           }
+          if (map[classification.label].pair.length >= MAX_PAIRS_PER_LABEL) { continue }
           map[classification.label].pair.push(new SolutionPair(phrase, classification))
         }
       }
@@ -46,6 +48,7 @@ class HashMapSolver extends BaseSolver {
               map[classification.label].pair.push(new SolutionPair(new Span(), classification))
             }
           }
+          if (map[classification.label].pair.length >= MAX_PAIRS_PER_LABEL) { continue }
           map[classification.label].pair.push(new SolutionPair(word, classification))
         }
       }


### PR DESCRIPTION
this simple PR adds two 'circuit breakers' within the `ExclusiveCartesianSolver` to mitigate the effects of long-running complex queries.

some (particularly long) queries can generate a large number of potential solutions, the main culprit is the `ExclusiveCartesianSolver`, which, as the name implies, produces a cross product of all non-overlapping classifications.

the problem is that in some degenerate cases (such as the example below) the sheer number of potential solutions can stall the CPU and therefore cascade performance issues on to any codebase which includes this module.

an obvious solution here is to add some 'circuit breakers' which detect if some of these arrays of values grow beyond a set threshold and prevents them from growing any larger.

the good news is that we can actually set these constants fairly high and still achieve our goals, the degenerate 'slow queries' are usually *an order of magnitude slower*, so simply providing *any* ceiling seems to be sufficient to prevent long running queries.

note: there is naturally a tradeoff here, we are gaining performance guarantees at the expense of discarding potentially superior solutions.

The way I've tuned this, all of the existing test cases pass (including the longer/complex examples).

So in a real-world scenario I suspect we will see no measurable difference in quality but with a significant reduction in worst-case performance, these constants may be adjusted/increased in the future if a need arises.

```bash
node bin/cli.js 'c mk v ba 1994 2000 323 c v ba 1994 2000 323 f iv bg 1987 1994 323 f mk iv bg 1987 1994 323 f mk v ba 1994 1998 323 f v ba 1994 1998 323 f vi bj 1998 2004 323 f/p mk vi bj 1998 2004 323 iii bf 1985 1991 323 1998 323 iii седан bf 1985 1991 323 iv bg 1989 1994 323 iv, седан'
```

```bash
# master
================================================================
SOLUTIONS (13962ms)
----------------------------------------------------------------
```

```bash
# this PR
================================================================
SOLUTIONS (112ms)
----------------------------------------------------------------
(0.10) ➜ [
  { street: 'v ba' },
  { housenumber: '1994' },
  { region: 'bg' },
  { country: 'mk' }
]
```