### PR TITLE
Update dictionaries to use correct ro diacritics characters

### DIFF
--- a/resources/libpostal/dictionaries/all/given_names.txt
+++ b/resources/libpostal/dictionaries/all/given_names.txt
@@ -8403,7 +8403,7 @@ Dragoje
 Dragoljub
 Dragomir
 Dragoslav
-Dragoş
+Dragoș
 Draga
 Dragan
 Dragana

--- a/resources/libpostal/dictionaries/all/surnames.txt
+++ b/resources/libpostal/dictionaries/all/surnames.txt
@@ -4085,7 +4085,7 @@ Vormer
 Vorganov
 Vorgrimler
 Vornholt
-Vornişel
+Vornișel
 Voráček
 Voráčová
 Vorbe
@@ -4349,7 +4349,7 @@ Vulević
 Vulliamy
 Vullo
 Vulpe
-Vulpeş
+Vulpeș
 Vulović
 Vultaggio
 Vujanić
@@ -4738,7 +4738,7 @@ Vălean
 Văluță
 Văideanu
 Văsie
-Vătăşoiu
+Vătășoiu
 Vēja
 Vējonis
 Vētra

--- a/resources/libpostal/dictionaries/all/surnames.txt
+++ b/resources/libpostal/dictionaries/all/surnames.txt
@@ -49039,7 +49039,7 @@ Uğurlu
 Şipal
 Şirin
 Şişli
-Ştefănescu
+Ștefănescu
 Žigeranović
 Žigić
 Živanović

--- a/resources/libpostal/dictionaries/all/surnames.txt
+++ b/resources/libpostal/dictionaries/all/surnames.txt
@@ -4735,7 +4735,7 @@ Văcăroiu
 Vădrariu
 Văduva
 Vălean
-Văluţă
+Văluță
 Văideanu
 Văsie
 Vătăşoiu
@@ -38654,7 +38654,7 @@ Tonge
 Tonguç
 Toninelli
 Tonini
-Toniţa
+Tonița
 Tonokura
 Tonon
 Tondre
@@ -44366,14 +44366,14 @@ Negro
 Negron
 Negroni
 Negru
-Negruţă
+Negruță
 Negi
 Negishi
 Negus
 Negussie
 Negash
 Negedu
-Negoiţescu
+Negoițescu
 Neil
 Neild
 Neill

--- a/resources/libpostal/dictionaries/ro/street_types.txt
+++ b/resources/libpostal/dictionaries/ro/street_types.txt
@@ -5,7 +5,7 @@ drumul
 fundătura|fundatura|fnd
 fundacul|fdc
 intrarea|int|intr
-piaţa|piata|piață|pta|pţa|p-ta|p-ţa
+piața|piata|piață|pta|pța|p-ta|p-ța
 strada|str
 stradela|str-la|sdla
 șoseaua|soseaua|sos|șos

--- a/resources/whosonfirst/dictionaries/locality/name:eng_x_preferred.txt
+++ b/resources/whosonfirst/dictionaries/locality/name:eng_x_preferred.txt
@@ -65351,7 +65351,7 @@ lipoven'
 sagaydaki
 satu-nou
 selemet
-Ştefan vodă
+Ștefan vodă
 antonesht'
 brezoya
 carahasani

--- a/resources/whosonfirst/dictionaries/locality/name:eng_x_preferred.txt
+++ b/resources/whosonfirst/dictionaries/locality/name:eng_x_preferred.txt
@@ -26183,7 +26183,7 @@ tigina
 chișinău
 tiraspol
 byelcy
-rîbniţa
+rîbnița
 maastricht
 helmond
 oss
@@ -26241,7 +26241,7 @@ slatina
 călărași
 targu jiu
 slobozia
-reşiţa
+reşița
 constanța
 târgovişte
 ramnicu valcea
@@ -26271,8 +26271,8 @@ miercurea-ciuc
 oradea
 vaslui
 barlad
-piatra neamţ
-bistriţa
+piatra neamț
+bistrița
 satu mare
 baia mare
 iași
@@ -37206,7 +37206,7 @@ ricse
 Șerbănești
 grănicești
 zvoriștea
-rădăuţi
+rădăuți
 calafindești
 zamostea
 dornești
@@ -55989,7 +55989,7 @@ rozavlea
 sălsig
 gârdani
 iapa
-sighetu marmaţiei
+sighetu marmației
 săpânța
 jeud
 băile borșa

--- a/resources/whosonfirst/dictionaries/locality/name:fra_x_preferred.txt
+++ b/resources/whosonfirst/dictionaries/locality/name:fra_x_preferred.txt
@@ -9021,7 +9021,7 @@ riga
 bender
 chişinău
 tiraspol
-municipalité de bălţi
+municipalité de bălți
 rîbnița
 maastricht
 helmond
@@ -9083,7 +9083,7 @@ drobeta turnu-severin
 slatina
 târgu jiu
 slobozia
-reşiţa
+reşița
 constanța
 târgoviste
 râmnicu vâlcea
@@ -9111,8 +9111,8 @@ turda
 oradea
 vaslui
 bârlad
-piatra neamţ
-bistriţa
+piatra neamț
+bistrița
 satu mare
 baia mare
 iași
@@ -19673,7 +19673,7 @@ pálháza
 vilmány
 sátoraljaújhely
 ricse
-rădăuţi
+rădăuți
 cândești
 malá lehota
 hriňová

--- a/resources/whosonfirst/dictionaries/locality/name:fra_x_preferred.txt
+++ b/resources/whosonfirst/dictionaries/locality/name:fra_x_preferred.txt
@@ -9019,7 +9019,7 @@ jelgava
 jurmala
 riga
 bender
-chişinău
+chișinău
 tiraspol
 municipalité de bălți
 rîbnița
@@ -9083,28 +9083,28 @@ drobeta turnu-severin
 slatina
 târgu jiu
 slobozia
-reşița
+reșița
 constanța
 târgoviste
 râmnicu vâlcea
-piteşti
-timişoara
-ploieşti
+pitești
+timișoara
+ploiești
 brăila
 buzău
 deva
 hunedoara
 tulcea
-braşov
-mediaş
+brașov
+mediaș
 sibiu
 arad
 alba iulia
-focşani
+focșani
 galați
 bacău
-oneşti
-târgu mureş
+onești
+târgu mureș
 zalău
 cluj-napoca
 turda
@@ -9117,7 +9117,7 @@ satu mare
 baia mare
 iași
 suceava
-botoşani
+botoșani
 nitra
 trnava
 banská bystrica

--- a/resources/whosonfirst/dictionaries/region/name:eng_x_preferred.txt
+++ b/resources/whosonfirst/dictionaries/region/name:eng_x_preferred.txt
@@ -4043,7 +4043,7 @@ vaslui
 neamt
 bistrita-nasaud
 satu mare
-maramureş county
+maramureș county
 iasi
 suceava
 botosani

--- a/resources/whosonfirst/dictionaries/region/name:eng_x_preferred.txt
+++ b/resources/whosonfirst/dictionaries/region/name:eng_x_preferred.txt
@@ -3797,11 +3797,11 @@ rezina
 Șoldănești district
 florești district
 drocia
-raionul edineţ
+raionul edineț
 briceni
 soroca
 dondușeni district
-raionul ocniţa
+raionul ocnița
 ciudad de méxico
 guerrero
 méxico

--- a/test/address.rom.test.js
+++ b/test/address.rom.test.js
@@ -20,6 +20,10 @@ const testcase = (test, common) => {
   assert('Calea Victoriei 54 Bucharest ', [
     { street: 'Calea Victoriei' }, { housenumber: '54' }, { locality: 'Bucharest' }
   ])
+
+  assert('Piața Montreal 1', [
+    { street: 'Piața Montreal' }, { housenumber: '1' }
+  ])
 }
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
:wave:
Hi,
Some of the characters used for diacritics in Romanian words are wrong. This PR updates them. A complete list of chars is here: https://en.wikipedia.org/wiki/List_of_Unicode_characters

- Replaced U+0163 - Latin Small Letter T with cedilla (ţ) with U+021B Latin Small Letter T with comma below (ț)
- Replaced U+015F (ş) with U+0219 (ș) for Romanian names
- Replaced U+015E (Ş) with U+0218 (Ș) for Romanian names
