### PR TITLE
Updated some german abbreviations & added support for fractional housenumbers

### DIFF
--- a/classifier/HouseNumberClassifier.js
+++ b/classifier/HouseNumberClassifier.js
@@ -15,7 +15,8 @@ class HouseNumberClassifier extends WordClassifier {
         /^(\d{1,5})[a-zA-Z\u0400-\u04FF]?\/(\d{1,5})$/.test(span.body) || // 1/135 or 1b/135 Style
         /^(\d{1,5})([nsewNSEW])(\d{1,5})[a-zA-Z]?$/.test(span.body) || // 6N23 Style (ie Kane County, IL)
         /^([nsewNSEW])(\d{1,5})([nsewNSEW]\d{1,5})?$/.test(span.body) // W350N5337 or N453 Style (ie Waukesha County, WI)
-        // /^\d{1,5}(к\d{1,5})?(с\d{1,5})?$/.test(span.body) // Russian style including korpus (cyrillic к) and stroenie (cyrillic с)
+        /^(\d{1,5}) (\d\/\d)?$/.test(span.body) || // 3 1/4 Style (ie Immenstadt im Allgäu, Germany)
+        // /^\d{1,5}(к\d{1,5})?(с\d{1,5})?$/.test(span.body) // Russian style including korpus (cyrillic к) and stroenie (cyrillic с)        
     ) {
       let confidence = 1
       let prev = span.graph.findOne('prev')

--- a/classifier/HouseNumberClassifier.test.js
+++ b/classifier/HouseNumberClassifier.test.js
@@ -133,6 +133,24 @@ module.exports.tests.forward_slash = (test) => {
   })
 }
 
+module.exports.tests.fraction_appendix = (test) => {
+  test('Fraction: 1 3/4', (t) => {
+    let s = classify('1 3/4')
+    t.deepEqual(s.classifications, { HouseNumberClassification: new HouseNumberClassification(1.0) })
+    t.end()
+  })
+    test('Fraction: 25 2/2', (t) => {
+    let s = classify('25 2/2')
+    t.deepEqual(s.classifications, { HouseNumberClassification: new HouseNumberClassification(1.0) })
+    t.end()
+  })
+  test('Fraction: 11 1/3', (t) => {
+    let s = classify('11 1/3')
+    t.deepEqual(s.classifications, { HouseNumberClassification: new HouseNumberClassification(1.0) })
+    t.end()
+  })
+}
+
 module.exports.tests.misc = (test) => {
   test('misc: 6N23', (t) => {
     let s = classify('6N23')

--- a/resources/libpostal/dictionaries/de/academic_degrees.txt
+++ b/resources/libpostal/dictionaries/de/academic_degrees.txt
@@ -1,5 +1,7 @@
-diplom ingenieur|dipl ing
-diplom kaufmann|dipl kfm
-doktor der medizin|dr med
-doktor der philosophie|dr phil
-magister|mag
+diplom ingenieur|dipl ing|dipl. ing.|dipl. ing
+diplom kaufmann|dipl kfm|dipl. kfm.|dipl. kfm
+doktor der medizin|dr med|dr. med.
+doktor der philosophie|dr phil|dr. phil.
+magister|mag|mag.
+bachelor of science|b.sc|b sc.|bachelor Sc.|b sc|b. sc
+master of science|m.sc|m sc.|master Sc.|m sc|m. sc

--- a/resources/libpostal/dictionaries/de/near.txt
+++ b/resources/libpostal/dictionaries/de/near.txt
@@ -1,4 +1,4 @@
-bei
+bei|b.
 hier in der nähe|hier in der nahe|hier in der naehe
 hier in der gegend
 in

--- a/resources/libpostal/dictionaries/de/place_names.txt
+++ b/resources/libpostal/dictionaries/de/place_names.txt
@@ -5,7 +5,7 @@ apotheke
 arzt
 allgemeiner deutscher automobil club|adac|a d a c
 auswartiges amt|aa|a a
-bahnhof
+bahnhof|bf|b f
 bank
 bar
 bauernhof
@@ -16,9 +16,9 @@ bundesrealgymnasium|brg|b r g
 bunker
 büro|buro|buero
 bustenhalter|bh
-busbahnhof
+busbahnhof|bbf
 café|cafe
-casino
+casino|kasino
 denkmal|dkm
 deutsche bahn|db|d b
 deutscher alpenverein|dav|d a v
@@ -30,7 +30,7 @@ fähranlegestelle|fahranlegestelle|faehranlegestelle
 fahrschule
 flughafen
 freiwillige feuerwehr|ff
-feuerwehr
+feuerwehr|fw
 gasthaus|gh
 gaststätte|gaststatte|gaststaette
 gasthof|ghf
@@ -41,13 +41,13 @@ geschäft|geschaft|geschaeft
 geselligkeitsverein
 gesundheitszentrum
 gericht
-grundschule
+grundschule|gs|g s
 hafen
 halle
 haus
 handelsakademie|hak
 handelsschule|hasch
-hauptbahnhof|hbf
+hauptbahnhof|hbf|h b f
 hochschule
 höhle|hohle
 höhere technische lehranstalt|htl|hohere technische lehranstalt|hoehere technische lehranstalt|h t l
@@ -70,12 +70,12 @@ kirche
 kläranlage|ka|klaranlage|klaeranlage
 kneipe
 konzentrationslager|kz|kl
-krankenhaus
+krankenhaus|kh|k h
 kulturzentrum
 magistratsabteilung|ma
 markt|mkt
 marktplatz|markt platz|markt pl|mkt pl|marktpl
-nachtklub
+nachtklub|nachtclub
 nationalpark|np|national park
 naturschutzgebiet|nsg
 neue mittelschule|nms
@@ -84,7 +84,7 @@ padagogische hochschule|ph
 park
 parkplatz
 pflegeheim
-polizei
+polizei|pol
 postamt
 rathaus
 recyclingeinrichtung

--- a/resources/libpostal/dictionaries/de/stopwords.txt
+++ b/resources/libpostal/dictionaries/de/stopwords.txt
@@ -3,37 +3,37 @@ an
 an der|a.d.|a.d|a d
 auf
 auf der|a.d.|a.d|a d
-bei|b
+bei|b|b.
 beim
 bis
-das
+das|d|d.
 de
-dem
-den
-der
-des
-die
+dem|d|d.
+den|d|d.
+der|d|d.
+des|d|d.
+die|d|d.
 du
-fur
-gegenuber
+fur|für|f.
+gegenuber|gegenüber|ggü.|ggu|g g u|g g ü 
 im|i
 in|i
 in der|i.d.|i.d|i d
-mit
+mit|m.
 nach
-nachst
+nachst|nächst
 neben
 ob|o
 oder|od
-uber
+uber|über
 und|&
 unter
-vor|v
-von|v
+vor|v|v.
+von|v|v.
 von der|v.d.|v.d|v d
-zu
+zu|z|z.
 zu der
 zur
 zu dem
-zwischen
-zum|z
+zwischen|zw.|z w
+zum|z|z.


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
- [X] Got a project with these type of housenumbers
- [X] Other project, where "bei Berlin" (near Berlin) won't be found caused by the name "b.Berlin"

---
#### Here's what actually got changed :clap:
- [x] Added some german abbreviations
- [x] Added support for fricitonal housenumber appendix like "3 1/4". Didn't knew that this was a thing until I got hands on this project. 
Examples:
- https://www.openstreetmap.org/way/207516185
- https://www.openstreetmap.org/way/207516186
- https://www.openstreetmap.org/way/319538694
- https://www.openstreetmap.org/way/173507661

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
Import the german osm data and try to find these buildings by their adress. As far as I concerned these are written down correctly in OSM 