### PR TITLE
Fix full stop error for '-singel'

### DIFF
--- a/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
@@ -4,3 +4,4 @@ dijk
 !plain|pln.
 plein|pln
 plantsoen|plnts
+singel|sngl

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -39,6 +39,10 @@ const testcase = (test, common) => {
     { street: 'Brinkstraat' }, { housenumber: '87' }, { postcode: '7512EC' }, { locality: 'Enschede' }
   ])
 
+  assert('Blekerssngl, Gouda', [
+    { street: 'Blekerssngl' }, { locality: 'Gouda' }
+  ])
+
   assert('Weerdsingel O.Z., Utrecht', [
     { street: 'Weerdsingel O.Z.' }, { locality: 'Utrecht' }
   ])


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
  - Fixes pelias/parser#165
  - Adds test case
---
#### Here's what actually got changed :clap:
- [x] add `singel|sngl` to `concatenated_suffixes_separable.txt`
- [x] add example `Blekerssngl, Gouda` as a testcase

---
#### Here's how others can test the changes :eyes:

- Without the change, both *Blekerssingel, Gouda*  and _Heren**sngl.**, Haarlem_ would pass, but _Weerdsngl, Utrecht_ without a full stop indicating the abbreviation would **not** pass.
- With this PR, all the variations mentioned above **do** pass
