### PR TITLE
Fix 'dreef' as street type

### DIFF
--- a/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
@@ -4,3 +4,4 @@ dijk
 !plain|pln.
 plein|pln
 plantsoen|plnts
+singel|sngl

--- a/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
+++ b/resources/pelias/dictionaries/libpostal/nl/concatenated_suffixes_separable.txt
@@ -1,6 +1,7 @@
 baan
 daal
 dijk
+dreef
 !plain|pln.
 plein|pln
 plantsoen|plnts

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -39,6 +39,10 @@ const testcase = (test, common) => {
     { street: 'Brinkstraat' }, { housenumber: '87' }, { postcode: '7512EC' }, { locality: 'Enschede' }
   ])
 
+  assert('Blekerssngl, Gouda', [
+    { street: 'Blekerssngl' }, { locality: 'Gouda' }
+  ])
+
   assert('Weerdsingel O.Z., Utrecht', [
     { street: 'Weerdsingel O.Z.' }, { locality: 'Utrecht' }
   ])

--- a/test/address.nld.test.js
+++ b/test/address.nld.test.js
@@ -13,6 +13,10 @@ const testcase = (test, common) => {
     { street: 'Bosserdijk' }, { locality: 'Hoogland' }
   ])
 
+  assert('Rubicondreef, Utrecht', [
+    { street: 'Rubicondreef' }, { locality: 'Utrecht' }
+  ])
+
   assert('St Ludgerusstraat, Utrecht', [
     { street: 'Ludgerusstraat' }, { locality: 'Utrecht' }
   ])


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

#### Here's the reason for this change :rocket:
  - Fixes pelias/parser#167
  - Adds test case

---
#### Here's what actually got changed :clap:
- [x] add `dreef` to `concatenated_suffixes_separable.txt`
- [x] add example *Rubicondreef, Utrecht* as a testcase

---
#### Here's how others can test the changes :eyes:
- Without the change, both _Rubicondreef, Utrecht_ and _Fazantendreef, Moordrecht_ would only be resolved to the locality.
- With this PR, the both the street names and locailty are recognised
