### PR TITLE
Upgrade to better-sqlite3-8.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stringbuffer": "^1.0.0"
   },
   "devDependencies": {
-    "better-sqlite3": "^7.4.1",
+    "better-sqlite3": "^8.5.0",
     "chalk": "^2.4.2",
     "csv-parse": "^4.4.1",
     "deep-eql": "^4.0.0",


### PR DESCRIPTION
This is the same version currently used in the `whosonfirst` and `placeholder` repos.

It's required for Node.js 20 support in https://github.com/pelias/pelias/issues/950