### PR TITLE
CI updates: Modern Node.js versions, action version updates, standard template

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -16,5 +16,6 @@ jobs:
           node-version: '${{ matrix.node-version }}'
       - name: Run unit tests
         run: |
+          [[ -f ./bin/ci-setup ]] && ./bin/ci-setup
           npm install
           npm run ci

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,9 +8,6 @@ jobs:
         os:
           - ubuntu-22.04
         node-version:
-          - 12.x
-          - 14.x
-          - 16.x
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         node-version:
           - 12.x
           - 14.x

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -12,9 +12,9 @@ jobs:
           - 14.x
           - 16.x
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v4
         with:
           node-version: '${{ matrix.node-version }}'
       - name: Run unit tests

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version:
+        node-version: [ 18.x, 20.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js
@@ -26,7 +26,7 @@ jobs:
     # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
     if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
     needs: [unit-tests, npm-publish]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker images

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,9 +8,9 @@ jobs:
     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Node.js
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
       - name: Run semantic-release
@@ -28,7 +28,7 @@ jobs:
     needs: [unit-tests, npm-publish]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Docker images
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
This PR includes a bunch of commits made by a script that standardizes as much as possible our CI config across all repositories.

First and foremost, it ensures we test all Node.js versions that are an LTS release, not EOL, and currently work with this repository.

Also, the CI OS version is now hardcoded to ubuntu-22.04. We fooled around with an organization wide CI variable to configure that, but it broke CI in forks and doesn't really help us much, so it's now undone.

If there are any other differences in Github Actions Workflow files, they are also now removed by using a standard template.

Finally, because this repository has a Dockerfile and we just [updated the Docker baseimage to support Node.js 18](https://github.com/pelias/docker-baseimage/pull/29), there is an empty commit to trigger a new major version release.

Connects https://github.com/pelias/pelias/issues/950
Connects https://github.com/pelias/pelias/issues/951