### PR TITLE
deps: Upgrade better-sqlite3 to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stringbuffer": "^1.0.0"
   },
   "devDependencies": {
-    "better-sqlite3": "^8.5.0",
+    "better-sqlite3": "^11.5.0",
     "chalk": "^2.4.2",
     "csv-parse": "^4.4.1",
     "deep-eql": "^4.0.0",


### PR DESCRIPTION
This is required to have precompiled binaries for Mac ARM systems, as well as other fixes I'm sure.